### PR TITLE
erlang: add 19.0 recipes

### DIFF
--- a/recipes-devtools/erlang/erlang-19.0-manifest.inc
+++ b/recipes-devtools/erlang/erlang-19.0-manifest.inc
@@ -1,0 +1,1416 @@
+
+# WARNING: This file is AUTO GENERATED: Manual edits will be lost next time I regenerate the file.
+# Generator: './generate-manifest --erlang-version 19.0 --outfile ../../../recipes-devtools/erlang/erlang-19.0-manifest.inc' Version 20160225 (C) 2002-2010 Michael 'Mickey' Lauer <mlauer@vanille-media.de>
+
+ 
+
+ERTS_VERSION = "8.0"
+PROVIDES+="${PN}-sasl-doc ${PN}-sasl-dbg ${PN}-sasl-dev ${PN}-sasl-staticdev ${PN}-sasl ${PN}-stdlib-doc ${PN}-stdlib-dbg ${PN}-stdlib-dev ${PN}-stdlib-staticdev ${PN}-stdlib ${PN}-kernel-doc ${PN}-kernel-dbg ${PN}-kernel-dev ${PN}-kernel-staticdev ${PN}-kernel ${PN}-tools-doc ${PN}-tools-dbg ${PN}-tools-dev ${PN}-tools-staticdev ${PN}-tools ${PN}-appmon-doc ${PN}-appmon-dbg ${PN}-appmon-dev ${PN}-appmon-staticdev ${PN}-appmon ${PN}-asn1-doc ${PN}-asn1-dbg ${PN}-asn1-dev ${PN}-asn1-staticdev ${PN}-asn1 ${PN}-common-test-doc ${PN}-common-test-dbg ${PN}-common-test-dev ${PN}-common-test-staticdev ${PN}-common-test ${PN}-compiler-doc ${PN}-compiler-dbg ${PN}-compiler-dev ${PN}-compiler-staticdev ${PN}-compiler ${PN}-cosevent-doc ${PN}-cosevent-dbg ${PN}-cosevent-dev ${PN}-cosevent-staticdev ${PN}-cosevent ${PN}-coseventdomain-doc ${PN}-coseventdomain-dbg ${PN}-coseventdomain-dev ${PN}-coseventdomain-staticdev ${PN}-coseventdomain ${PN}-cosfiletransfer-doc ${PN}-cosfiletransfer-dbg ${PN}-cosfiletransfer-dev ${PN}-cosfiletransfer-staticdev ${PN}-cosfiletransfer ${PN}-cosnotification-doc ${PN}-cosnotification-dbg ${PN}-cosnotification-dev ${PN}-cosnotification-staticdev ${PN}-cosnotification ${PN}-cosproperty-doc ${PN}-cosproperty-dbg ${PN}-cosproperty-dev ${PN}-cosproperty-staticdev ${PN}-cosproperty ${PN}-costime-doc ${PN}-costime-dbg ${PN}-costime-dev ${PN}-costime-staticdev ${PN}-costime ${PN}-costransactions-doc ${PN}-costransactions-dbg ${PN}-costransactions-dev ${PN}-costransactions-staticdev ${PN}-costransactions ${PN}-crypto-doc ${PN}-crypto-dbg ${PN}-crypto-dev ${PN}-crypto-staticdev ${PN}-crypto ${PN}-debugger-doc ${PN}-debugger-dbg ${PN}-debugger-dev ${PN}-debugger-staticdev ${PN}-debugger ${PN}-dialyzer-doc ${PN}-dialyzer-dbg ${PN}-dialyzer-dev ${PN}-dialyzer-staticdev ${PN}-dialyzer ${PN}-diameter-doc ${PN}-diameter-dbg ${PN}-diameter-dev ${PN}-diameter-staticdev ${PN}-diameter ${PN}-edoc-doc ${PN}-edoc-dbg ${PN}-edoc-dev ${PN}-edoc-staticdev ${PN}-edoc ${PN}-eldap-doc ${PN}-eldap-dbg ${PN}-eldap-dev ${PN}-eldap-staticdev ${PN}-eldap ${PN}-erl-docgen-doc ${PN}-erl-docgen-dbg ${PN}-erl-docgen-dev ${PN}-erl-docgen-staticdev ${PN}-erl-docgen ${PN}-erl-interface-doc ${PN}-erl-interface-dbg ${PN}-erl-interface-dev ${PN}-erl-interface-staticdev ${PN}-erl-interface ${PN}-et-doc ${PN}-et-dbg ${PN}-et-dev ${PN}-et-staticdev ${PN}-et ${PN}-eunit-doc ${PN}-eunit-dbg ${PN}-eunit-dev ${PN}-eunit-staticdev ${PN}-eunit ${PN}-gs-doc ${PN}-gs-dbg ${PN}-gs-dev ${PN}-gs-staticdev ${PN}-gs ${PN}-hipe-doc ${PN}-hipe-dbg ${PN}-hipe-dev ${PN}-hipe-staticdev ${PN}-hipe ${PN}-ic-doc ${PN}-ic-dbg ${PN}-ic-dev ${PN}-ic-staticdev ${PN}-ic ${PN}-inets-doc ${PN}-inets-dbg ${PN}-inets-dev ${PN}-inets-staticdev ${PN}-inets ${PN}-jinterface-doc ${PN}-jinterface-dbg ${PN}-jinterface-dev ${PN}-jinterface-staticdev ${PN}-jinterface ${PN}-megaco-doc ${PN}-megaco-dbg ${PN}-megaco-dev ${PN}-megaco-staticdev ${PN}-megaco ${PN}-mnesia-doc ${PN}-mnesia-dbg ${PN}-mnesia-dev ${PN}-mnesia-staticdev ${PN}-mnesia ${PN}-observer-doc ${PN}-observer-dbg ${PN}-observer-dev ${PN}-observer-staticdev ${PN}-observer ${PN}-orber-doc ${PN}-orber-dbg ${PN}-orber-dev ${PN}-orber-staticdev ${PN}-orber ${PN}-os-mon-doc ${PN}-os-mon-dbg ${PN}-os-mon-dev ${PN}-os-mon-staticdev ${PN}-os-mon ${PN}-otp-mibs-doc ${PN}-otp-mibs-dbg ${PN}-otp-mibs-dev ${PN}-otp-mibs-staticdev ${PN}-otp-mibs ${PN}-parsetools-doc ${PN}-parsetools-dbg ${PN}-parsetools-dev ${PN}-parsetools-staticdev ${PN}-parsetools ${PN}-percept-doc ${PN}-percept-dbg ${PN}-percept-dev ${PN}-percept-staticdev ${PN}-percept ${PN}-pman-doc ${PN}-pman-dbg ${PN}-pman-dev ${PN}-pman-staticdev ${PN}-pman ${PN}-public-key-doc ${PN}-public-key-dbg ${PN}-public-key-dev ${PN}-public-key-staticdev ${PN}-public-key ${PN}-reltool-doc ${PN}-reltool-dbg ${PN}-reltool-dev ${PN}-reltool-staticdev ${PN}-reltool ${PN}-runtime-tools-doc ${PN}-runtime-tools-dbg ${PN}-runtime-tools-dev ${PN}-runtime-tools-staticdev ${PN}-runtime-tools ${PN}-snmp-doc ${PN}-snmp-dbg ${PN}-snmp-dev ${PN}-snmp-staticdev ${PN}-snmp ${PN}-ssh-doc ${PN}-ssh-dbg ${PN}-ssh-dev ${PN}-ssh-staticdev ${PN}-ssh ${PN}-ssl-doc ${PN}-ssl-dbg ${PN}-ssl-dev ${PN}-ssl-staticdev ${PN}-ssl ${PN}-syntax-tools-doc ${PN}-syntax-tools-dbg ${PN}-syntax-tools-dev ${PN}-syntax-tools-staticdev ${PN}-syntax-tools ${PN}-test-server-doc ${PN}-test-server-dbg ${PN}-test-server-dev ${PN}-test-server-staticdev ${PN}-test-server ${PN}-toolbar-doc ${PN}-toolbar-dbg ${PN}-toolbar-dev ${PN}-toolbar-staticdev ${PN}-toolbar ${PN}-tv-doc ${PN}-tv-dbg ${PN}-tv-dev ${PN}-tv-staticdev ${PN}-tv ${PN}-typer-doc ${PN}-typer-dbg ${PN}-typer-dev ${PN}-typer-staticdev ${PN}-typer ${PN}-webtool-doc ${PN}-webtool-dbg ${PN}-webtool-dev ${PN}-webtool-staticdev ${PN}-webtool ${PN}-xmerl-doc ${PN}-xmerl-dbg ${PN}-xmerl-dev ${PN}-xmerl-staticdev ${PN}-xmerl ${PN}-odbc-doc ${PN}-odbc-dbg ${PN}-odbc-dev ${PN}-odbc-staticdev ${PN}-odbc ${PN}-ose-doc ${PN}-ose-dbg ${PN}-ose-dev ${PN}-ose-staticdev ${PN}-ose ${PN}-erts-doc ${PN}-erts-dbg ${PN}-erts-dev ${PN}-erts-staticdev ${PN}-erts ${PN}-doc ${PN}-dev ${PN}-dbg ${PN}-staticdev ${PN} "
+
+PACKAGES="${PN}-dbg ${PN}-sasl-doc ${PN}-sasl-dbg ${PN}-sasl-dev ${PN}-sasl-staticdev ${PN}-sasl ${PN}-stdlib-doc ${PN}-stdlib-dbg ${PN}-stdlib-dev ${PN}-stdlib-staticdev ${PN}-stdlib ${PN}-kernel-doc ${PN}-kernel-dbg ${PN}-kernel-dev ${PN}-kernel-staticdev ${PN}-kernel ${PN}-tools-doc ${PN}-tools-dbg ${PN}-tools-dev ${PN}-tools-staticdev ${PN}-tools ${PN}-appmon-doc ${PN}-appmon-dbg ${PN}-appmon-dev ${PN}-appmon-staticdev ${PN}-appmon ${PN}-asn1-doc ${PN}-asn1-dbg ${PN}-asn1-dev ${PN}-asn1-staticdev ${PN}-asn1 ${PN}-common-test-doc ${PN}-common-test-dbg ${PN}-common-test-dev ${PN}-common-test-staticdev ${PN}-common-test ${PN}-compiler-doc ${PN}-compiler-dbg ${PN}-compiler-dev ${PN}-compiler-staticdev ${PN}-compiler ${PN}-cosevent-doc ${PN}-cosevent-dbg ${PN}-cosevent-dev ${PN}-cosevent-staticdev ${PN}-cosevent ${PN}-coseventdomain-doc ${PN}-coseventdomain-dbg ${PN}-coseventdomain-dev ${PN}-coseventdomain-staticdev ${PN}-coseventdomain ${PN}-cosfiletransfer-doc ${PN}-cosfiletransfer-dbg ${PN}-cosfiletransfer-dev ${PN}-cosfiletransfer-staticdev ${PN}-cosfiletransfer ${PN}-cosnotification-doc ${PN}-cosnotification-dbg ${PN}-cosnotification-dev ${PN}-cosnotification-staticdev ${PN}-cosnotification ${PN}-cosproperty-doc ${PN}-cosproperty-dbg ${PN}-cosproperty-dev ${PN}-cosproperty-staticdev ${PN}-cosproperty ${PN}-costime-doc ${PN}-costime-dbg ${PN}-costime-dev ${PN}-costime-staticdev ${PN}-costime ${PN}-costransactions-doc ${PN}-costransactions-dbg ${PN}-costransactions-dev ${PN}-costransactions-staticdev ${PN}-costransactions ${PN}-crypto-doc ${PN}-crypto-dbg ${PN}-crypto-dev ${PN}-crypto-staticdev ${PN}-crypto ${PN}-debugger-doc ${PN}-debugger-dbg ${PN}-debugger-dev ${PN}-debugger-staticdev ${PN}-debugger ${PN}-dialyzer-doc ${PN}-dialyzer-dbg ${PN}-dialyzer-dev ${PN}-dialyzer-staticdev ${PN}-dialyzer ${PN}-diameter-doc ${PN}-diameter-dbg ${PN}-diameter-dev ${PN}-diameter-staticdev ${PN}-diameter ${PN}-edoc-doc ${PN}-edoc-dbg ${PN}-edoc-dev ${PN}-edoc-staticdev ${PN}-edoc ${PN}-eldap-doc ${PN}-eldap-dbg ${PN}-eldap-dev ${PN}-eldap-staticdev ${PN}-eldap ${PN}-erl-docgen-doc ${PN}-erl-docgen-dbg ${PN}-erl-docgen-dev ${PN}-erl-docgen-staticdev ${PN}-erl-docgen ${PN}-erl-interface-doc ${PN}-erl-interface-dbg ${PN}-erl-interface-dev ${PN}-erl-interface-staticdev ${PN}-erl-interface ${PN}-et-doc ${PN}-et-dbg ${PN}-et-dev ${PN}-et-staticdev ${PN}-et ${PN}-eunit-doc ${PN}-eunit-dbg ${PN}-eunit-dev ${PN}-eunit-staticdev ${PN}-eunit ${PN}-gs-doc ${PN}-gs-dbg ${PN}-gs-dev ${PN}-gs-staticdev ${PN}-gs ${PN}-hipe-doc ${PN}-hipe-dbg ${PN}-hipe-dev ${PN}-hipe-staticdev ${PN}-hipe ${PN}-ic-doc ${PN}-ic-dbg ${PN}-ic-dev ${PN}-ic-staticdev ${PN}-ic ${PN}-inets-doc ${PN}-inets-dbg ${PN}-inets-dev ${PN}-inets-staticdev ${PN}-inets ${PN}-jinterface-doc ${PN}-jinterface-dbg ${PN}-jinterface-dev ${PN}-jinterface-staticdev ${PN}-jinterface ${PN}-megaco-doc ${PN}-megaco-dbg ${PN}-megaco-dev ${PN}-megaco-staticdev ${PN}-megaco ${PN}-mnesia-doc ${PN}-mnesia-dbg ${PN}-mnesia-dev ${PN}-mnesia-staticdev ${PN}-mnesia ${PN}-observer-doc ${PN}-observer-dbg ${PN}-observer-dev ${PN}-observer-staticdev ${PN}-observer ${PN}-orber-doc ${PN}-orber-dbg ${PN}-orber-dev ${PN}-orber-staticdev ${PN}-orber ${PN}-os-mon-doc ${PN}-os-mon-dbg ${PN}-os-mon-dev ${PN}-os-mon-staticdev ${PN}-os-mon ${PN}-otp-mibs-doc ${PN}-otp-mibs-dbg ${PN}-otp-mibs-dev ${PN}-otp-mibs-staticdev ${PN}-otp-mibs ${PN}-parsetools-doc ${PN}-parsetools-dbg ${PN}-parsetools-dev ${PN}-parsetools-staticdev ${PN}-parsetools ${PN}-percept-doc ${PN}-percept-dbg ${PN}-percept-dev ${PN}-percept-staticdev ${PN}-percept ${PN}-pman-doc ${PN}-pman-dbg ${PN}-pman-dev ${PN}-pman-staticdev ${PN}-pman ${PN}-public-key-doc ${PN}-public-key-dbg ${PN}-public-key-dev ${PN}-public-key-staticdev ${PN}-public-key ${PN}-reltool-doc ${PN}-reltool-dbg ${PN}-reltool-dev ${PN}-reltool-staticdev ${PN}-reltool ${PN}-runtime-tools-doc ${PN}-runtime-tools-dbg ${PN}-runtime-tools-dev ${PN}-runtime-tools-staticdev ${PN}-runtime-tools ${PN}-snmp-doc ${PN}-snmp-dbg ${PN}-snmp-dev ${PN}-snmp-staticdev ${PN}-snmp ${PN}-ssh-doc ${PN}-ssh-dbg ${PN}-ssh-dev ${PN}-ssh-staticdev ${PN}-ssh ${PN}-ssl-doc ${PN}-ssl-dbg ${PN}-ssl-dev ${PN}-ssl-staticdev ${PN}-ssl ${PN}-syntax-tools-doc ${PN}-syntax-tools-dbg ${PN}-syntax-tools-dev ${PN}-syntax-tools-staticdev ${PN}-syntax-tools ${PN}-test-server-doc ${PN}-test-server-dbg ${PN}-test-server-dev ${PN}-test-server-staticdev ${PN}-test-server ${PN}-toolbar-doc ${PN}-toolbar-dbg ${PN}-toolbar-dev ${PN}-toolbar-staticdev ${PN}-toolbar ${PN}-tv-doc ${PN}-tv-dbg ${PN}-tv-dev ${PN}-tv-staticdev ${PN}-tv ${PN}-typer-doc ${PN}-typer-dbg ${PN}-typer-dev ${PN}-typer-staticdev ${PN}-typer ${PN}-webtool-doc ${PN}-webtool-dbg ${PN}-webtool-dev ${PN}-webtool-staticdev ${PN}-webtool ${PN}-xmerl-doc ${PN}-xmerl-dbg ${PN}-xmerl-dev ${PN}-xmerl-staticdev ${PN}-xmerl ${PN}-odbc-doc ${PN}-odbc-dbg ${PN}-odbc-dev ${PN}-odbc-staticdev ${PN}-odbc ${PN}-ose-doc ${PN}-ose-dbg ${PN}-ose-dev ${PN}-ose-staticdev ${PN}-ose ${PN}-erts-doc ${PN}-erts-dbg ${PN}-erts-dev ${PN}-erts-staticdev ${PN}-erts ${PN}-doc ${PN}-dev ${PN}-staticdev ${PN} ${PN}-modules"
+
+ALLOW_EMPTY_${PN}-sasl-doc="1"
+DESCRIPTION_${PN}-sasl-doc=""
+RDEPENDS_${PN}-sasl-doc=""
+FILES_${PN}-sasl-doc="${libdir}/erlang/lib/sasl-*/examples ${libdir}/erlang/lib/sasl-*/doc ${libdir}/erlang/lib/sasl-*/man "
+
+ALLOW_EMPTY_${PN}-sasl-dbg="1"
+DESCRIPTION_${PN}-sasl-dbg=""
+RDEPENDS_${PN}-sasl-dbg=""
+FILES_${PN}-sasl-dbg="${libdir}/erlang/lib/sasl-*/bin/.debug ${libdir}/erlang/lib/sasl-*/lib/.debug ${libdir}/erlang/lib/sasl-*/priv/lib/.debug ${libdir}/erlang/lib/sasl-*/priv/obj/.debug ${libdir}/erlang/lib/sasl-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-sasl-dev="1"
+DESCRIPTION_${PN}-sasl-dev=""
+RDEPENDS_${PN}-sasl-dev=""
+FILES_${PN}-sasl-dev="${libdir}/erlang/lib/sasl-*/*src ${libdir}/erlang/lib/sasl-*/include ${libdir}/erlang/lib/sasl-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-sasl-staticdev="1"
+DESCRIPTION_${PN}-sasl-staticdev=""
+RDEPENDS_${PN}-sasl-staticdev=""
+FILES_${PN}-sasl-staticdev="${libdir}/erlang/lib/sasl-*/lib/*.a ${libdir}/erlang/lib/sasl-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-sasl="1"
+DESCRIPTION_${PN}-sasl=""
+RDEPENDS_${PN}-sasl=""
+FILES_${PN}-sasl="${libdir}/erlang/lib/sasl-* "
+
+ALLOW_EMPTY_${PN}-stdlib-doc="1"
+DESCRIPTION_${PN}-stdlib-doc=""
+RDEPENDS_${PN}-stdlib-doc=""
+FILES_${PN}-stdlib-doc="${libdir}/erlang/lib/stdlib-*/examples ${libdir}/erlang/lib/stdlib-*/doc ${libdir}/erlang/lib/stdlib-*/man "
+
+ALLOW_EMPTY_${PN}-stdlib-dbg="1"
+DESCRIPTION_${PN}-stdlib-dbg=""
+RDEPENDS_${PN}-stdlib-dbg=""
+FILES_${PN}-stdlib-dbg="${libdir}/erlang/lib/stdlib-*/bin/.debug ${libdir}/erlang/lib/stdlib-*/lib/.debug ${libdir}/erlang/lib/stdlib-*/priv/lib/.debug ${libdir}/erlang/lib/stdlib-*/priv/obj/.debug ${libdir}/erlang/lib/stdlib-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-stdlib-dev="1"
+DESCRIPTION_${PN}-stdlib-dev=""
+RDEPENDS_${PN}-stdlib-dev=""
+FILES_${PN}-stdlib-dev="${libdir}/erlang/lib/stdlib-*/*src ${libdir}/erlang/lib/stdlib-*/include ${libdir}/erlang/lib/stdlib-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-stdlib-staticdev="1"
+DESCRIPTION_${PN}-stdlib-staticdev=""
+RDEPENDS_${PN}-stdlib-staticdev=""
+FILES_${PN}-stdlib-staticdev="${libdir}/erlang/lib/stdlib-*/lib/*.a ${libdir}/erlang/lib/stdlib-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-stdlib="1"
+DESCRIPTION_${PN}-stdlib=""
+RDEPENDS_${PN}-stdlib=""
+FILES_${PN}-stdlib="${libdir}/erlang/lib/stdlib-* "
+
+ALLOW_EMPTY_${PN}-kernel-doc="1"
+DESCRIPTION_${PN}-kernel-doc=""
+RDEPENDS_${PN}-kernel-doc=""
+FILES_${PN}-kernel-doc="${libdir}/erlang/lib/kernel-*/examples ${libdir}/erlang/lib/kernel-*/doc ${libdir}/erlang/lib/kernel-*/man "
+
+ALLOW_EMPTY_${PN}-kernel-dbg="1"
+DESCRIPTION_${PN}-kernel-dbg=""
+RDEPENDS_${PN}-kernel-dbg=""
+FILES_${PN}-kernel-dbg="${libdir}/erlang/lib/kernel-*/bin/.debug ${libdir}/erlang/lib/kernel-*/lib/.debug ${libdir}/erlang/lib/kernel-*/priv/lib/.debug ${libdir}/erlang/lib/kernel-*/priv/obj/.debug ${libdir}/erlang/lib/kernel-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-kernel-dev="1"
+DESCRIPTION_${PN}-kernel-dev=""
+RDEPENDS_${PN}-kernel-dev=""
+FILES_${PN}-kernel-dev="${libdir}/erlang/lib/kernel-*/*src ${libdir}/erlang/lib/kernel-*/include ${libdir}/erlang/lib/kernel-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-kernel-staticdev="1"
+DESCRIPTION_${PN}-kernel-staticdev=""
+RDEPENDS_${PN}-kernel-staticdev=""
+FILES_${PN}-kernel-staticdev="${libdir}/erlang/lib/kernel-*/lib/*.a ${libdir}/erlang/lib/kernel-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-kernel="1"
+DESCRIPTION_${PN}-kernel=""
+RDEPENDS_${PN}-kernel=""
+FILES_${PN}-kernel="${libdir}/erlang/lib/kernel-* "
+
+ALLOW_EMPTY_${PN}-tools-doc="1"
+DESCRIPTION_${PN}-tools-doc=""
+RDEPENDS_${PN}-tools-doc=""
+FILES_${PN}-tools-doc="${libdir}/erlang/lib/tools-*/examples ${libdir}/erlang/lib/tools-*/doc ${libdir}/erlang/lib/tools-*/man "
+
+ALLOW_EMPTY_${PN}-tools-dbg="1"
+DESCRIPTION_${PN}-tools-dbg=""
+RDEPENDS_${PN}-tools-dbg=""
+FILES_${PN}-tools-dbg="${libdir}/erlang/lib/tools-*/bin/.debug ${libdir}/erlang/lib/tools-*/lib/.debug ${libdir}/erlang/lib/tools-*/priv/lib/.debug ${libdir}/erlang/lib/tools-*/priv/obj/.debug ${libdir}/erlang/lib/tools-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-tools-dev="1"
+DESCRIPTION_${PN}-tools-dev=""
+RDEPENDS_${PN}-tools-dev=""
+FILES_${PN}-tools-dev="${libdir}/erlang/lib/tools-*/*src ${libdir}/erlang/lib/tools-*/include ${libdir}/erlang/lib/tools-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-tools-staticdev="1"
+DESCRIPTION_${PN}-tools-staticdev=""
+RDEPENDS_${PN}-tools-staticdev=""
+FILES_${PN}-tools-staticdev="${libdir}/erlang/lib/tools-*/lib/*.a ${libdir}/erlang/lib/tools-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-tools="1"
+DESCRIPTION_${PN}-tools=""
+RDEPENDS_${PN}-tools=""
+FILES_${PN}-tools="${libdir}/erlang/lib/tools-* "
+
+ALLOW_EMPTY_${PN}-appmon-doc="1"
+DESCRIPTION_${PN}-appmon-doc=""
+RDEPENDS_${PN}-appmon-doc=""
+FILES_${PN}-appmon-doc="${libdir}/erlang/lib/appmon-*/examples ${libdir}/erlang/lib/appmon-*/doc ${libdir}/erlang/lib/appmon-*/man "
+
+ALLOW_EMPTY_${PN}-appmon-dbg="1"
+DESCRIPTION_${PN}-appmon-dbg=""
+RDEPENDS_${PN}-appmon-dbg=""
+FILES_${PN}-appmon-dbg="${libdir}/erlang/lib/appmon-*/bin/.debug ${libdir}/erlang/lib/appmon-*/lib/.debug ${libdir}/erlang/lib/appmon-*/priv/lib/.debug ${libdir}/erlang/lib/appmon-*/priv/obj/.debug ${libdir}/erlang/lib/appmon-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-appmon-dev="1"
+DESCRIPTION_${PN}-appmon-dev=""
+RDEPENDS_${PN}-appmon-dev=""
+FILES_${PN}-appmon-dev="${libdir}/erlang/lib/appmon-*/*src ${libdir}/erlang/lib/appmon-*/include ${libdir}/erlang/lib/appmon-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-appmon-staticdev="1"
+DESCRIPTION_${PN}-appmon-staticdev=""
+RDEPENDS_${PN}-appmon-staticdev=""
+FILES_${PN}-appmon-staticdev="${libdir}/erlang/lib/appmon-*/lib/*.a ${libdir}/erlang/lib/appmon-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-appmon="1"
+DESCRIPTION_${PN}-appmon=""
+RDEPENDS_${PN}-appmon=""
+FILES_${PN}-appmon="${libdir}/erlang/lib/appmon-* "
+
+ALLOW_EMPTY_${PN}-asn1-doc="1"
+DESCRIPTION_${PN}-asn1-doc=""
+RDEPENDS_${PN}-asn1-doc=""
+FILES_${PN}-asn1-doc="${libdir}/erlang/lib/asn1-*/examples ${libdir}/erlang/lib/asn1-*/doc ${libdir}/erlang/lib/asn1-*/man "
+
+ALLOW_EMPTY_${PN}-asn1-dbg="1"
+DESCRIPTION_${PN}-asn1-dbg=""
+RDEPENDS_${PN}-asn1-dbg=""
+FILES_${PN}-asn1-dbg="${libdir}/erlang/lib/asn1-*/bin/.debug ${libdir}/erlang/lib/asn1-*/lib/.debug ${libdir}/erlang/lib/asn1-*/priv/lib/.debug ${libdir}/erlang/lib/asn1-*/priv/obj/.debug ${libdir}/erlang/lib/asn1-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-asn1-dev="1"
+DESCRIPTION_${PN}-asn1-dev=""
+RDEPENDS_${PN}-asn1-dev=""
+FILES_${PN}-asn1-dev="${libdir}/erlang/lib/asn1-*/*src ${libdir}/erlang/lib/asn1-*/include ${libdir}/erlang/lib/asn1-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-asn1-staticdev="1"
+DESCRIPTION_${PN}-asn1-staticdev=""
+RDEPENDS_${PN}-asn1-staticdev=""
+FILES_${PN}-asn1-staticdev="${libdir}/erlang/lib/asn1-*/lib/*.a ${libdir}/erlang/lib/asn1-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-asn1="1"
+DESCRIPTION_${PN}-asn1=""
+RDEPENDS_${PN}-asn1=""
+FILES_${PN}-asn1="${libdir}/erlang/lib/asn1-* "
+
+ALLOW_EMPTY_${PN}-common-test-doc="1"
+DESCRIPTION_${PN}-common-test-doc=""
+RDEPENDS_${PN}-common-test-doc=""
+FILES_${PN}-common-test-doc="${libdir}/erlang/lib/common-test-*/examples ${libdir}/erlang/lib/common-test-*/doc ${libdir}/erlang/lib/common-test-*/man "
+
+ALLOW_EMPTY_${PN}-common-test-dbg="1"
+DESCRIPTION_${PN}-common-test-dbg=""
+RDEPENDS_${PN}-common-test-dbg=""
+FILES_${PN}-common-test-dbg="${libdir}/erlang/lib/common_test-*/bin/.debug ${libdir}/erlang/lib/common_test-*/lib/.debug ${libdir}/erlang/lib/common_test-*/priv/lib/.debug ${libdir}/erlang/lib/common_test-*/priv/obj/.debug ${libdir}/erlang/lib/common_test-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-common-test-dev="1"
+DESCRIPTION_${PN}-common-test-dev=""
+RDEPENDS_${PN}-common-test-dev=""
+FILES_${PN}-common-test-dev="${libdir}/erlang/lib/common_test-*/*src ${libdir}/erlang/lib/common_test-*/include ${libdir}/erlang/lib/common_test-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-common-test-staticdev="1"
+DESCRIPTION_${PN}-common-test-staticdev=""
+RDEPENDS_${PN}-common-test-staticdev=""
+FILES_${PN}-common-test-staticdev="${libdir}/erlang/lib/common_test-*/lib/*.a ${libdir}/erlang/lib/common_test-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-common-test="1"
+DESCRIPTION_${PN}-common-test=""
+RDEPENDS_${PN}-common-test=""
+FILES_${PN}-common-test="${bindir}/ct_run ${libdir}/erlang/bin/ct_run ${libdir}/erlang/lib/common_test-* ${libdir}/erlang/erts-*/bin/ct_run "
+
+ALLOW_EMPTY_${PN}-compiler-doc="1"
+DESCRIPTION_${PN}-compiler-doc=""
+RDEPENDS_${PN}-compiler-doc=""
+FILES_${PN}-compiler-doc="${libdir}/erlang/lib/compiler-*/examples ${libdir}/erlang/lib/compiler-*/doc ${libdir}/erlang/lib/compiler-*/man "
+
+ALLOW_EMPTY_${PN}-compiler-dbg="1"
+DESCRIPTION_${PN}-compiler-dbg=""
+RDEPENDS_${PN}-compiler-dbg=""
+FILES_${PN}-compiler-dbg="${libdir}/erlang/lib/compiler-*/bin/.debug ${libdir}/erlang/lib/compiler-*/lib/.debug ${libdir}/erlang/lib/compiler-*/priv/lib/.debug ${libdir}/erlang/lib/compiler-*/priv/obj/.debug ${libdir}/erlang/lib/compiler-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-compiler-dev="1"
+DESCRIPTION_${PN}-compiler-dev=""
+RDEPENDS_${PN}-compiler-dev=""
+FILES_${PN}-compiler-dev="${libdir}/erlang/lib/compiler-*/*src ${libdir}/erlang/lib/compiler-*/include ${libdir}/erlang/lib/compiler-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-compiler-staticdev="1"
+DESCRIPTION_${PN}-compiler-staticdev=""
+RDEPENDS_${PN}-compiler-staticdev=""
+FILES_${PN}-compiler-staticdev="${libdir}/erlang/lib/compiler-*/lib/*.a ${libdir}/erlang/lib/compiler-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-compiler="1"
+DESCRIPTION_${PN}-compiler=""
+RDEPENDS_${PN}-compiler=""
+FILES_${PN}-compiler="${bindir}/erlc ${libdir}/erlang/bin/erlc ${libdir}/erlang/lib/compiler-* ${libdir}/erlang/erts-*/bin/erlc "
+
+ALLOW_EMPTY_${PN}-cosevent-doc="1"
+DESCRIPTION_${PN}-cosevent-doc=""
+RDEPENDS_${PN}-cosevent-doc=""
+FILES_${PN}-cosevent-doc="${libdir}/erlang/lib/cosevent-*/examples ${libdir}/erlang/lib/cosevent-*/doc ${libdir}/erlang/lib/cosevent-*/man "
+
+ALLOW_EMPTY_${PN}-cosevent-dbg="1"
+DESCRIPTION_${PN}-cosevent-dbg=""
+RDEPENDS_${PN}-cosevent-dbg=""
+FILES_${PN}-cosevent-dbg="${libdir}/erlang/lib/cosEvent-*/bin/.debug ${libdir}/erlang/lib/cosEvent-*/lib/.debug ${libdir}/erlang/lib/cosEvent-*/priv/lib/.debug ${libdir}/erlang/lib/cosEvent-*/priv/obj/.debug ${libdir}/erlang/lib/cosEvent-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-cosevent-dev="1"
+DESCRIPTION_${PN}-cosevent-dev=""
+RDEPENDS_${PN}-cosevent-dev=""
+FILES_${PN}-cosevent-dev="${libdir}/erlang/lib/cosEvent-*/src ${libdir}/erlang/lib/cosEvent-*/include "
+
+ALLOW_EMPTY_${PN}-cosevent-staticdev="1"
+DESCRIPTION_${PN}-cosevent-staticdev=""
+RDEPENDS_${PN}-cosevent-staticdev=""
+FILES_${PN}-cosevent-staticdev="${libdir}/erlang/lib/cosEvent-*/lib/*.a ${libdir}/erlang/lib/cosEvent-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-cosevent="1"
+DESCRIPTION_${PN}-cosevent=""
+RDEPENDS_${PN}-cosevent=""
+FILES_${PN}-cosevent="${libdir}/erlang/lib/cosEvent-* "
+
+ALLOW_EMPTY_${PN}-coseventdomain-doc="1"
+DESCRIPTION_${PN}-coseventdomain-doc=""
+RDEPENDS_${PN}-coseventdomain-doc=""
+FILES_${PN}-coseventdomain-doc="${libdir}/erlang/lib/coseventdomain-*/examples ${libdir}/erlang/lib/coseventdomain-*/doc ${libdir}/erlang/lib/coseventdomain-*/man "
+
+ALLOW_EMPTY_${PN}-coseventdomain-dbg="1"
+DESCRIPTION_${PN}-coseventdomain-dbg=""
+RDEPENDS_${PN}-coseventdomain-dbg=""
+FILES_${PN}-coseventdomain-dbg="${libdir}/erlang/lib/cosEventDomain-*/bin/.debug ${libdir}/erlang/lib/cosEventDomain-*/lib/.debug ${libdir}/erlang/lib/cosEventDomain-*/priv/lib/.debug ${libdir}/erlang/lib/cosEventDomain-*/priv/obj/.debug ${libdir}/erlang/lib/cosEventDomain-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-coseventdomain-dev="1"
+DESCRIPTION_${PN}-coseventdomain-dev=""
+RDEPENDS_${PN}-coseventdomain-dev=""
+FILES_${PN}-coseventdomain-dev="${libdir}/erlang/lib/cosEventDomain-*/src ${libdir}/erlang/lib/cosEventDomain-*/include "
+
+ALLOW_EMPTY_${PN}-coseventdomain-staticdev="1"
+DESCRIPTION_${PN}-coseventdomain-staticdev=""
+RDEPENDS_${PN}-coseventdomain-staticdev=""
+FILES_${PN}-coseventdomain-staticdev="${libdir}/erlang/lib/cosEventDomain-*/lib/*.a ${libdir}/erlang/lib/cosEventDomain-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-coseventdomain="1"
+DESCRIPTION_${PN}-coseventdomain=""
+RDEPENDS_${PN}-coseventdomain=""
+FILES_${PN}-coseventdomain="${libdir}/erlang/lib/cosEventDomain-* "
+
+ALLOW_EMPTY_${PN}-cosfiletransfer-doc="1"
+DESCRIPTION_${PN}-cosfiletransfer-doc=""
+RDEPENDS_${PN}-cosfiletransfer-doc=""
+FILES_${PN}-cosfiletransfer-doc="${libdir}/erlang/lib/cosfiletransfer-*/examples ${libdir}/erlang/lib/cosfiletransfer-*/doc ${libdir}/erlang/lib/cosfiletransfer-*/man "
+
+ALLOW_EMPTY_${PN}-cosfiletransfer-dbg="1"
+DESCRIPTION_${PN}-cosfiletransfer-dbg=""
+RDEPENDS_${PN}-cosfiletransfer-dbg=""
+FILES_${PN}-cosfiletransfer-dbg="${libdir}/erlang/lib/cosFileTransfer-*/bin/.debug ${libdir}/erlang/lib/cosFileTransfer-*/lib/.debug ${libdir}/erlang/lib/cosFileTransfer-*/priv/lib/.debug ${libdir}/erlang/lib/cosFileTransfer-*/priv/obj/.debug ${libdir}/erlang/lib/cosFileTransfer-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-cosfiletransfer-dev="1"
+DESCRIPTION_${PN}-cosfiletransfer-dev=""
+RDEPENDS_${PN}-cosfiletransfer-dev=""
+FILES_${PN}-cosfiletransfer-dev="${libdir}/erlang/lib/cosFileTransfer-*/src ${libdir}/erlang/lib/cosFileTransfer-*/include "
+
+ALLOW_EMPTY_${PN}-cosfiletransfer-staticdev="1"
+DESCRIPTION_${PN}-cosfiletransfer-staticdev=""
+RDEPENDS_${PN}-cosfiletransfer-staticdev=""
+FILES_${PN}-cosfiletransfer-staticdev="${libdir}/erlang/lib/cosFileTransfer-*/lib/*.a ${libdir}/erlang/lib/cosFileTransfer-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-cosfiletransfer="1"
+DESCRIPTION_${PN}-cosfiletransfer=""
+RDEPENDS_${PN}-cosfiletransfer=""
+FILES_${PN}-cosfiletransfer="${libdir}/erlang/lib/cosFileTransfer-* "
+
+ALLOW_EMPTY_${PN}-cosnotification-doc="1"
+DESCRIPTION_${PN}-cosnotification-doc=""
+RDEPENDS_${PN}-cosnotification-doc=""
+FILES_${PN}-cosnotification-doc="${libdir}/erlang/lib/cosnotification-*/examples ${libdir}/erlang/lib/cosnotification-*/doc ${libdir}/erlang/lib/cosnotification-*/man "
+
+ALLOW_EMPTY_${PN}-cosnotification-dbg="1"
+DESCRIPTION_${PN}-cosnotification-dbg=""
+RDEPENDS_${PN}-cosnotification-dbg=""
+FILES_${PN}-cosnotification-dbg="${libdir}/erlang/lib/cosNotification-*/bin/.debug ${libdir}/erlang/lib/cosNotification-*/lib/.debug ${libdir}/erlang/lib/cosNotification-*/priv/lib/.debug ${libdir}/erlang/lib/cosNotification-*/priv/obj/.debug ${libdir}/erlang/lib/cosNotification-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-cosnotification-dev="1"
+DESCRIPTION_${PN}-cosnotification-dev=""
+RDEPENDS_${PN}-cosnotification-dev=""
+FILES_${PN}-cosnotification-dev="${libdir}/erlang/lib/cosNotification-*/src ${libdir}/erlang/lib/cosNotification-*/include "
+
+ALLOW_EMPTY_${PN}-cosnotification-staticdev="1"
+DESCRIPTION_${PN}-cosnotification-staticdev=""
+RDEPENDS_${PN}-cosnotification-staticdev=""
+FILES_${PN}-cosnotification-staticdev="${libdir}/erlang/lib/cosNotification-*/lib/*.a ${libdir}/erlang/lib/cosNotification-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-cosnotification="1"
+DESCRIPTION_${PN}-cosnotification=""
+RDEPENDS_${PN}-cosnotification=""
+FILES_${PN}-cosnotification="${libdir}/erlang/lib/cosNotification-* "
+
+ALLOW_EMPTY_${PN}-cosproperty-doc="1"
+DESCRIPTION_${PN}-cosproperty-doc=""
+RDEPENDS_${PN}-cosproperty-doc=""
+FILES_${PN}-cosproperty-doc="${libdir}/erlang/lib/cosproperty-*/examples ${libdir}/erlang/lib/cosproperty-*/doc ${libdir}/erlang/lib/cosproperty-*/man "
+
+ALLOW_EMPTY_${PN}-cosproperty-dbg="1"
+DESCRIPTION_${PN}-cosproperty-dbg=""
+RDEPENDS_${PN}-cosproperty-dbg=""
+FILES_${PN}-cosproperty-dbg="${libdir}/erlang/lib/cosProperty-*/bin/.debug ${libdir}/erlang/lib/cosProperty-*/lib/.debug ${libdir}/erlang/lib/cosProperty-*/priv/lib/.debug ${libdir}/erlang/lib/cosProperty-*/priv/obj/.debug ${libdir}/erlang/lib/cosProperty-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-cosproperty-dev="1"
+DESCRIPTION_${PN}-cosproperty-dev=""
+RDEPENDS_${PN}-cosproperty-dev=""
+FILES_${PN}-cosproperty-dev="${libdir}/erlang/lib/cosProperty-*/src ${libdir}/erlang/lib/cosProperty-*/include "
+
+ALLOW_EMPTY_${PN}-cosproperty-staticdev="1"
+DESCRIPTION_${PN}-cosproperty-staticdev=""
+RDEPENDS_${PN}-cosproperty-staticdev=""
+FILES_${PN}-cosproperty-staticdev="${libdir}/erlang/lib/cosProperty-*/lib/*.a ${libdir}/erlang/lib/cosProperty-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-cosproperty="1"
+DESCRIPTION_${PN}-cosproperty=""
+RDEPENDS_${PN}-cosproperty=""
+FILES_${PN}-cosproperty="${libdir}/erlang/lib/cosProperty-* "
+
+ALLOW_EMPTY_${PN}-costime-doc="1"
+DESCRIPTION_${PN}-costime-doc=""
+RDEPENDS_${PN}-costime-doc=""
+FILES_${PN}-costime-doc="${libdir}/erlang/lib/costime-*/examples ${libdir}/erlang/lib/costime-*/doc ${libdir}/erlang/lib/costime-*/man "
+
+ALLOW_EMPTY_${PN}-costime-dbg="1"
+DESCRIPTION_${PN}-costime-dbg=""
+RDEPENDS_${PN}-costime-dbg=""
+FILES_${PN}-costime-dbg="${libdir}/erlang/lib/cosTime-*/bin/.debug ${libdir}/erlang/lib/cosTime-*/lib/.debug ${libdir}/erlang/lib/cosTime-*/priv/lib/.debug ${libdir}/erlang/lib/cosTime-*/priv/obj/.debug ${libdir}/erlang/lib/cosTime-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-costime-dev="1"
+DESCRIPTION_${PN}-costime-dev=""
+RDEPENDS_${PN}-costime-dev=""
+FILES_${PN}-costime-dev="${libdir}/erlang/lib/cosTime-*/src ${libdir}/erlang/lib/cosTime-*/include "
+
+ALLOW_EMPTY_${PN}-costime-staticdev="1"
+DESCRIPTION_${PN}-costime-staticdev=""
+RDEPENDS_${PN}-costime-staticdev=""
+FILES_${PN}-costime-staticdev="${libdir}/erlang/lib/cosTime-*/lib/*.a ${libdir}/erlang/lib/cosTime-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-costime="1"
+DESCRIPTION_${PN}-costime=""
+RDEPENDS_${PN}-costime=""
+FILES_${PN}-costime="${libdir}/erlang/lib/cosTime-* "
+
+ALLOW_EMPTY_${PN}-costransactions-doc="1"
+DESCRIPTION_${PN}-costransactions-doc=""
+RDEPENDS_${PN}-costransactions-doc=""
+FILES_${PN}-costransactions-doc="${libdir}/erlang/lib/costransactions-*/examples ${libdir}/erlang/lib/costransactions-*/doc ${libdir}/erlang/lib/costransactions-*/man "
+
+ALLOW_EMPTY_${PN}-costransactions-dbg="1"
+DESCRIPTION_${PN}-costransactions-dbg=""
+RDEPENDS_${PN}-costransactions-dbg=""
+FILES_${PN}-costransactions-dbg="${libdir}/erlang/lib/cosTransactions-*/bin/.debug ${libdir}/erlang/lib/cosTransactions-*/lib/.debug ${libdir}/erlang/lib/cosTransactions-*/priv/lib/.debug ${libdir}/erlang/lib/cosTransactions-*/priv/obj/.debug ${libdir}/erlang/lib/cosTransactions-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-costransactions-dev="1"
+DESCRIPTION_${PN}-costransactions-dev=""
+RDEPENDS_${PN}-costransactions-dev=""
+FILES_${PN}-costransactions-dev="${libdir}/erlang/lib/cosTransactions-*/src ${libdir}/erlang/lib/cosTransactions-*/include "
+
+ALLOW_EMPTY_${PN}-costransactions-staticdev="1"
+DESCRIPTION_${PN}-costransactions-staticdev=""
+RDEPENDS_${PN}-costransactions-staticdev=""
+FILES_${PN}-costransactions-staticdev="${libdir}/erlang/lib/cosTransactions-*/lib/*.a ${libdir}/erlang/lib/cosTransactions-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-costransactions="1"
+DESCRIPTION_${PN}-costransactions=""
+RDEPENDS_${PN}-costransactions=""
+FILES_${PN}-costransactions="${libdir}/erlang/lib/cosTransactions-* "
+
+ALLOW_EMPTY_${PN}-crypto-doc="1"
+DESCRIPTION_${PN}-crypto-doc=""
+RDEPENDS_${PN}-crypto-doc=""
+FILES_${PN}-crypto-doc="${libdir}/erlang/lib/crypto-*/examples ${libdir}/erlang/lib/crypto-*/doc ${libdir}/erlang/lib/crypto-*/man "
+
+ALLOW_EMPTY_${PN}-crypto-dbg="1"
+DESCRIPTION_${PN}-crypto-dbg=""
+RDEPENDS_${PN}-crypto-dbg=""
+FILES_${PN}-crypto-dbg="${libdir}/erlang/lib/crypto-*/bin/.debug ${libdir}/erlang/lib/crypto-*/lib/.debug ${libdir}/erlang/lib/crypto-*/priv/lib/.debug ${libdir}/erlang/lib/crypto-*/priv/obj/.debug ${libdir}/erlang/lib/crypto-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-crypto-dev="1"
+DESCRIPTION_${PN}-crypto-dev=""
+RDEPENDS_${PN}-crypto-dev=""
+FILES_${PN}-crypto-dev="${libdir}/erlang/lib/crypto-*/*src ${libdir}/erlang/lib/crypto-*/include ${libdir}/erlang/lib/crypto-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-crypto-staticdev="1"
+DESCRIPTION_${PN}-crypto-staticdev=""
+RDEPENDS_${PN}-crypto-staticdev=""
+FILES_${PN}-crypto-staticdev="${libdir}/erlang/lib/crypto-*/lib/*.a ${libdir}/erlang/lib/crypto-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-crypto="1"
+DESCRIPTION_${PN}-crypto=""
+RDEPENDS_${PN}-crypto=""
+FILES_${PN}-crypto="${libdir}/erlang/lib/crypto-* "
+
+ALLOW_EMPTY_${PN}-debugger-doc="1"
+DESCRIPTION_${PN}-debugger-doc=""
+RDEPENDS_${PN}-debugger-doc=""
+FILES_${PN}-debugger-doc="${libdir}/erlang/lib/debugger-*/examples ${libdir}/erlang/lib/debugger-*/doc ${libdir}/erlang/lib/debugger-*/man "
+
+ALLOW_EMPTY_${PN}-debugger-dbg="1"
+DESCRIPTION_${PN}-debugger-dbg=""
+RDEPENDS_${PN}-debugger-dbg=""
+FILES_${PN}-debugger-dbg="${libdir}/erlang/lib/debugger-*/bin/.debug ${libdir}/erlang/lib/debugger-*/lib/.debug ${libdir}/erlang/lib/debugger-*/priv/lib/.debug ${libdir}/erlang/lib/debugger-*/priv/obj/.debug ${libdir}/erlang/lib/debugger-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-debugger-dev="1"
+DESCRIPTION_${PN}-debugger-dev=""
+RDEPENDS_${PN}-debugger-dev=""
+FILES_${PN}-debugger-dev="${libdir}/erlang/lib/debugger-*/*src ${libdir}/erlang/lib/debugger-*/include ${libdir}/erlang/lib/debugger-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-debugger-staticdev="1"
+DESCRIPTION_${PN}-debugger-staticdev=""
+RDEPENDS_${PN}-debugger-staticdev=""
+FILES_${PN}-debugger-staticdev="${libdir}/erlang/lib/debugger-*/lib/*.a ${libdir}/erlang/lib/debugger-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-debugger="1"
+DESCRIPTION_${PN}-debugger=""
+RDEPENDS_${PN}-debugger=""
+FILES_${PN}-debugger="${libdir}/erlang/lib/debugger-* "
+
+ALLOW_EMPTY_${PN}-dialyzer-doc="1"
+DESCRIPTION_${PN}-dialyzer-doc=""
+RDEPENDS_${PN}-dialyzer-doc=""
+FILES_${PN}-dialyzer-doc="${libdir}/erlang/lib/dialyzer-*/examples ${libdir}/erlang/lib/dialyzer-*/doc ${libdir}/erlang/lib/dialyzer-*/man "
+
+ALLOW_EMPTY_${PN}-dialyzer-dbg="1"
+DESCRIPTION_${PN}-dialyzer-dbg=""
+RDEPENDS_${PN}-dialyzer-dbg=""
+FILES_${PN}-dialyzer-dbg="${libdir}/erlang/lib/dialyzer-*/bin/.debug ${libdir}/erlang/lib/dialyzer-*/lib/.debug ${libdir}/erlang/lib/dialyzer-*/priv/lib/.debug ${libdir}/erlang/lib/dialyzer-*/priv/obj/.debug ${libdir}/erlang/lib/dialyzer-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-dialyzer-dev="1"
+DESCRIPTION_${PN}-dialyzer-dev=""
+RDEPENDS_${PN}-dialyzer-dev=""
+FILES_${PN}-dialyzer-dev="${libdir}/erlang/lib/dialyzer-*/*src ${libdir}/erlang/lib/dialyzer-*/include ${libdir}/erlang/lib/dialyzer-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-dialyzer-staticdev="1"
+DESCRIPTION_${PN}-dialyzer-staticdev=""
+RDEPENDS_${PN}-dialyzer-staticdev=""
+FILES_${PN}-dialyzer-staticdev="${libdir}/erlang/lib/dialyzer-*/lib/*.a ${libdir}/erlang/lib/dialyzer-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-dialyzer="1"
+DESCRIPTION_${PN}-dialyzer=""
+RDEPENDS_${PN}-dialyzer=""
+FILES_${PN}-dialyzer="${bindir}/dialyzer ${libdir}/erlang/bin/dialyzer ${libdir}/erlang/lib/dialyzer-* ${libdir}/erlang/erts-*/bin/dialyzer "
+
+ALLOW_EMPTY_${PN}-diameter-doc="1"
+DESCRIPTION_${PN}-diameter-doc=""
+RDEPENDS_${PN}-diameter-doc=""
+FILES_${PN}-diameter-doc="${libdir}/erlang/lib/diameter-*/examples ${libdir}/erlang/lib/diameter-*/doc ${libdir}/erlang/lib/diameter-*/man "
+
+ALLOW_EMPTY_${PN}-diameter-dbg="1"
+DESCRIPTION_${PN}-diameter-dbg=""
+RDEPENDS_${PN}-diameter-dbg=""
+FILES_${PN}-diameter-dbg="${libdir}/erlang/lib/diameter-*/bin/.debug ${libdir}/erlang/lib/diameter-*/lib/.debug ${libdir}/erlang/lib/diameter-*/priv/lib/.debug ${libdir}/erlang/lib/diameter-*/priv/obj/.debug ${libdir}/erlang/lib/diameter-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-diameter-dev="1"
+DESCRIPTION_${PN}-diameter-dev=""
+RDEPENDS_${PN}-diameter-dev=""
+FILES_${PN}-diameter-dev="${libdir}/erlang/lib/diameter-*/*src ${libdir}/erlang/lib/diameter-*/include ${libdir}/erlang/lib/diameter-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-diameter-staticdev="1"
+DESCRIPTION_${PN}-diameter-staticdev=""
+RDEPENDS_${PN}-diameter-staticdev=""
+FILES_${PN}-diameter-staticdev="${libdir}/erlang/lib/diameter-*/lib/*.a ${libdir}/erlang/lib/diameter-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-diameter="1"
+DESCRIPTION_${PN}-diameter=""
+RDEPENDS_${PN}-diameter=""
+FILES_${PN}-diameter="${libdir}/erlang/lib/diameter-* "
+
+ALLOW_EMPTY_${PN}-edoc-doc="1"
+DESCRIPTION_${PN}-edoc-doc=""
+RDEPENDS_${PN}-edoc-doc=""
+FILES_${PN}-edoc-doc="${libdir}/erlang/lib/edoc-*/examples ${libdir}/erlang/lib/edoc-*/doc ${libdir}/erlang/lib/edoc-*/man "
+
+ALLOW_EMPTY_${PN}-edoc-dbg="1"
+DESCRIPTION_${PN}-edoc-dbg=""
+RDEPENDS_${PN}-edoc-dbg=""
+FILES_${PN}-edoc-dbg="${libdir}/erlang/lib/edoc-*/bin/.debug ${libdir}/erlang/lib/edoc-*/lib/.debug ${libdir}/erlang/lib/edoc-*/priv/lib/.debug ${libdir}/erlang/lib/edoc-*/priv/obj/.debug ${libdir}/erlang/lib/edoc-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-edoc-dev="1"
+DESCRIPTION_${PN}-edoc-dev=""
+RDEPENDS_${PN}-edoc-dev=""
+FILES_${PN}-edoc-dev="${libdir}/erlang/lib/edoc-*/*src ${libdir}/erlang/lib/edoc-*/include ${libdir}/erlang/lib/edoc-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-edoc-staticdev="1"
+DESCRIPTION_${PN}-edoc-staticdev=""
+RDEPENDS_${PN}-edoc-staticdev=""
+FILES_${PN}-edoc-staticdev="${libdir}/erlang/lib/edoc-*/lib/*.a ${libdir}/erlang/lib/edoc-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-edoc="1"
+DESCRIPTION_${PN}-edoc=""
+RDEPENDS_${PN}-edoc=""
+FILES_${PN}-edoc="${libdir}/erlang/lib/edoc-* "
+
+ALLOW_EMPTY_${PN}-eldap-doc="1"
+DESCRIPTION_${PN}-eldap-doc=""
+RDEPENDS_${PN}-eldap-doc=""
+FILES_${PN}-eldap-doc="${libdir}/erlang/lib/eldap-*/examples ${libdir}/erlang/lib/eldap-*/doc ${libdir}/erlang/lib/eldap-*/man "
+
+ALLOW_EMPTY_${PN}-eldap-dbg="1"
+DESCRIPTION_${PN}-eldap-dbg=""
+RDEPENDS_${PN}-eldap-dbg=""
+FILES_${PN}-eldap-dbg="${libdir}/erlang/lib/eldap-*/bin/.debug ${libdir}/erlang/lib/eldap-*/lib/.debug ${libdir}/erlang/lib/eldap-*/priv/lib/.debug ${libdir}/erlang/lib/eldap-*/priv/obj/.debug ${libdir}/erlang/lib/eldap-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-eldap-dev="1"
+DESCRIPTION_${PN}-eldap-dev=""
+RDEPENDS_${PN}-eldap-dev=""
+FILES_${PN}-eldap-dev="${libdir}/erlang/lib/eldap-*/*src ${libdir}/erlang/lib/eldap-*/include ${libdir}/erlang/lib/eldap-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-eldap-staticdev="1"
+DESCRIPTION_${PN}-eldap-staticdev=""
+RDEPENDS_${PN}-eldap-staticdev=""
+FILES_${PN}-eldap-staticdev="${libdir}/erlang/lib/eldap-*/lib/*.a ${libdir}/erlang/lib/eldap-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-eldap="1"
+DESCRIPTION_${PN}-eldap=""
+RDEPENDS_${PN}-eldap=""
+FILES_${PN}-eldap="${libdir}/erlang/lib/eldap-* "
+
+ALLOW_EMPTY_${PN}-erl-docgen-doc="1"
+DESCRIPTION_${PN}-erl-docgen-doc=""
+RDEPENDS_${PN}-erl-docgen-doc=""
+FILES_${PN}-erl-docgen-doc="${libdir}/erlang/lib/erl-docgen-*/examples ${libdir}/erlang/lib/erl-docgen-*/doc ${libdir}/erlang/lib/erl-docgen-*/man "
+
+ALLOW_EMPTY_${PN}-erl-docgen-dbg="1"
+DESCRIPTION_${PN}-erl-docgen-dbg=""
+RDEPENDS_${PN}-erl-docgen-dbg=""
+FILES_${PN}-erl-docgen-dbg="${libdir}/erlang/lib/erl_docgen-*/bin/.debug ${libdir}/erlang/lib/erl_docgen-*/lib/.debug ${libdir}/erlang/lib/erl_docgen-*/priv/lib/.debug ${libdir}/erlang/lib/erl_docgen-*/priv/obj/.debug ${libdir}/erlang/lib/erl_docgen-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-erl-docgen-dev="1"
+DESCRIPTION_${PN}-erl-docgen-dev=""
+RDEPENDS_${PN}-erl-docgen-dev=""
+FILES_${PN}-erl-docgen-dev="${libdir}/erlang/lib/erl_docgen-*/*src ${libdir}/erlang/lib/erl_docgen-*/include ${libdir}/erlang/lib/erl_docgen-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-erl-docgen-staticdev="1"
+DESCRIPTION_${PN}-erl-docgen-staticdev=""
+RDEPENDS_${PN}-erl-docgen-staticdev=""
+FILES_${PN}-erl-docgen-staticdev="${libdir}/erlang/lib/erl_docgen-*/lib/*.a ${libdir}/erlang/lib/erl_docgen-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-erl-docgen="1"
+DESCRIPTION_${PN}-erl-docgen=""
+RDEPENDS_${PN}-erl-docgen=""
+FILES_${PN}-erl-docgen="${libdir}/erlang/lib/erl_docgen-* "
+
+ALLOW_EMPTY_${PN}-erl-interface-doc="1"
+DESCRIPTION_${PN}-erl-interface-doc=""
+RDEPENDS_${PN}-erl-interface-doc=""
+FILES_${PN}-erl-interface-doc="${libdir}/erlang/lib/erl-interface-*/examples ${libdir}/erlang/lib/erl-interface-*/doc ${libdir}/erlang/lib/erl-interface-*/man "
+
+ALLOW_EMPTY_${PN}-erl-interface-dbg="1"
+DESCRIPTION_${PN}-erl-interface-dbg=""
+RDEPENDS_${PN}-erl-interface-dbg=""
+FILES_${PN}-erl-interface-dbg="${libdir}/erlang/lib/erl_interface-*/bin/.debug ${libdir}/erlang/lib/erl_interface-*/lib/.debug ${libdir}/erlang/lib/erl_interface-*/priv/lib/.debug ${libdir}/erlang/lib/erl_interface-*/priv/obj/.debug ${libdir}/erlang/lib/erl_interface-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-erl-interface-dev="1"
+DESCRIPTION_${PN}-erl-interface-dev=""
+RDEPENDS_${PN}-erl-interface-dev=""
+FILES_${PN}-erl-interface-dev="${libdir}/erlang/lib/erl_interface-*/*src ${libdir}/erlang/lib/erl_interface-*/include ${libdir}/erlang/lib/erl_interface-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-erl-interface-staticdev="1"
+DESCRIPTION_${PN}-erl-interface-staticdev=""
+RDEPENDS_${PN}-erl-interface-staticdev=""
+FILES_${PN}-erl-interface-staticdev="${libdir}/erlang/lib/erl_interface-*/lib/*.a ${libdir}/erlang/lib/erl_interface-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-erl-interface="1"
+DESCRIPTION_${PN}-erl-interface=""
+RDEPENDS_${PN}-erl-interface=""
+FILES_${PN}-erl-interface="${libdir}/erlang/lib/erl_interface-* "
+
+ALLOW_EMPTY_${PN}-et-doc="1"
+DESCRIPTION_${PN}-et-doc=""
+RDEPENDS_${PN}-et-doc=""
+FILES_${PN}-et-doc="${libdir}/erlang/lib/et-*/examples ${libdir}/erlang/lib/et-*/doc ${libdir}/erlang/lib/et-*/man "
+
+ALLOW_EMPTY_${PN}-et-dbg="1"
+DESCRIPTION_${PN}-et-dbg=""
+RDEPENDS_${PN}-et-dbg=""
+FILES_${PN}-et-dbg="${libdir}/erlang/lib/et-*/bin/.debug ${libdir}/erlang/lib/et-*/lib/.debug ${libdir}/erlang/lib/et-*/priv/lib/.debug ${libdir}/erlang/lib/et-*/priv/obj/.debug ${libdir}/erlang/lib/et-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-et-dev="1"
+DESCRIPTION_${PN}-et-dev=""
+RDEPENDS_${PN}-et-dev=""
+FILES_${PN}-et-dev="${libdir}/erlang/lib/et-*/*src ${libdir}/erlang/lib/et-*/include ${libdir}/erlang/lib/et-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-et-staticdev="1"
+DESCRIPTION_${PN}-et-staticdev=""
+RDEPENDS_${PN}-et-staticdev=""
+FILES_${PN}-et-staticdev="${libdir}/erlang/lib/et-*/lib/*.a ${libdir}/erlang/lib/et-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-et="1"
+DESCRIPTION_${PN}-et=""
+RDEPENDS_${PN}-et=""
+FILES_${PN}-et="${libdir}/erlang/lib/et-* "
+
+ALLOW_EMPTY_${PN}-eunit-doc="1"
+DESCRIPTION_${PN}-eunit-doc=""
+RDEPENDS_${PN}-eunit-doc=""
+FILES_${PN}-eunit-doc="${libdir}/erlang/lib/eunit-*/examples ${libdir}/erlang/lib/eunit-*/doc ${libdir}/erlang/lib/eunit-*/man "
+
+ALLOW_EMPTY_${PN}-eunit-dbg="1"
+DESCRIPTION_${PN}-eunit-dbg=""
+RDEPENDS_${PN}-eunit-dbg=""
+FILES_${PN}-eunit-dbg="${libdir}/erlang/lib/eunit-*/bin/.debug ${libdir}/erlang/lib/eunit-*/lib/.debug ${libdir}/erlang/lib/eunit-*/priv/lib/.debug ${libdir}/erlang/lib/eunit-*/priv/obj/.debug ${libdir}/erlang/lib/eunit-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-eunit-dev="1"
+DESCRIPTION_${PN}-eunit-dev=""
+RDEPENDS_${PN}-eunit-dev=""
+FILES_${PN}-eunit-dev="${libdir}/erlang/lib/eunit-*/*src ${libdir}/erlang/lib/eunit-*/include ${libdir}/erlang/lib/eunit-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-eunit-staticdev="1"
+DESCRIPTION_${PN}-eunit-staticdev=""
+RDEPENDS_${PN}-eunit-staticdev=""
+FILES_${PN}-eunit-staticdev="${libdir}/erlang/lib/eunit-*/lib/*.a ${libdir}/erlang/lib/eunit-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-eunit="1"
+DESCRIPTION_${PN}-eunit=""
+RDEPENDS_${PN}-eunit=""
+FILES_${PN}-eunit="${libdir}/erlang/lib/eunit-* "
+
+ALLOW_EMPTY_${PN}-gs-doc="1"
+DESCRIPTION_${PN}-gs-doc=""
+RDEPENDS_${PN}-gs-doc=""
+FILES_${PN}-gs-doc="${libdir}/erlang/lib/gs-*/examples ${libdir}/erlang/lib/gs-*/doc ${libdir}/erlang/lib/gs-*/man "
+
+ALLOW_EMPTY_${PN}-gs-dbg="1"
+DESCRIPTION_${PN}-gs-dbg=""
+RDEPENDS_${PN}-gs-dbg=""
+FILES_${PN}-gs-dbg="${libdir}/erlang/lib/gs-*/bin/.debug ${libdir}/erlang/lib/gs-*/lib/.debug ${libdir}/erlang/lib/gs-*/priv/lib/.debug ${libdir}/erlang/lib/gs-*/priv/obj/.debug ${libdir}/erlang/lib/gs-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-gs-dev="1"
+DESCRIPTION_${PN}-gs-dev=""
+RDEPENDS_${PN}-gs-dev=""
+FILES_${PN}-gs-dev="${libdir}/erlang/lib/gs-*/*src ${libdir}/erlang/lib/gs-*/include ${libdir}/erlang/lib/gs-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-gs-staticdev="1"
+DESCRIPTION_${PN}-gs-staticdev=""
+RDEPENDS_${PN}-gs-staticdev=""
+FILES_${PN}-gs-staticdev="${libdir}/erlang/lib/gs-*/lib/*.a ${libdir}/erlang/lib/gs-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-gs="1"
+DESCRIPTION_${PN}-gs=""
+RDEPENDS_${PN}-gs=""
+FILES_${PN}-gs="${libdir}/erlang/lib/gs-* "
+
+ALLOW_EMPTY_${PN}-hipe-doc="1"
+DESCRIPTION_${PN}-hipe-doc=""
+RDEPENDS_${PN}-hipe-doc=""
+FILES_${PN}-hipe-doc="${libdir}/erlang/lib/hipe-*/examples ${libdir}/erlang/lib/hipe-*/doc ${libdir}/erlang/lib/hipe-*/man "
+
+ALLOW_EMPTY_${PN}-hipe-dbg="1"
+DESCRIPTION_${PN}-hipe-dbg=""
+RDEPENDS_${PN}-hipe-dbg=""
+FILES_${PN}-hipe-dbg="${libdir}/erlang/lib/hipe-*/bin/.debug ${libdir}/erlang/lib/hipe-*/lib/.debug ${libdir}/erlang/lib/hipe-*/priv/lib/.debug ${libdir}/erlang/lib/hipe-*/priv/obj/.debug ${libdir}/erlang/lib/hipe-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-hipe-dev="1"
+DESCRIPTION_${PN}-hipe-dev=""
+RDEPENDS_${PN}-hipe-dev=""
+FILES_${PN}-hipe-dev="${libdir}/erlang/lib/hipe-*/*src ${libdir}/erlang/lib/hipe-*/include ${libdir}/erlang/lib/hipe-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-hipe-staticdev="1"
+DESCRIPTION_${PN}-hipe-staticdev=""
+RDEPENDS_${PN}-hipe-staticdev=""
+FILES_${PN}-hipe-staticdev="${libdir}/erlang/lib/hipe-*/lib/*.a ${libdir}/erlang/lib/hipe-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-hipe="1"
+DESCRIPTION_${PN}-hipe=""
+RDEPENDS_${PN}-hipe=""
+FILES_${PN}-hipe="${libdir}/erlang/lib/hipe-* "
+
+ALLOW_EMPTY_${PN}-ic-doc="1"
+DESCRIPTION_${PN}-ic-doc=""
+RDEPENDS_${PN}-ic-doc=""
+FILES_${PN}-ic-doc="${libdir}/erlang/lib/ic-*/examples ${libdir}/erlang/lib/ic-*/doc ${libdir}/erlang/lib/ic-*/man "
+
+ALLOW_EMPTY_${PN}-ic-dbg="1"
+DESCRIPTION_${PN}-ic-dbg=""
+RDEPENDS_${PN}-ic-dbg=""
+FILES_${PN}-ic-dbg="${libdir}/erlang/lib/ic-*/bin/.debug ${libdir}/erlang/lib/ic-*/lib/.debug ${libdir}/erlang/lib/ic-*/priv/lib/.debug ${libdir}/erlang/lib/ic-*/priv/obj/.debug ${libdir}/erlang/lib/ic-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-ic-dev="1"
+DESCRIPTION_${PN}-ic-dev=""
+RDEPENDS_${PN}-ic-dev=""
+FILES_${PN}-ic-dev="${libdir}/erlang/lib/ic-*/*src ${libdir}/erlang/lib/ic-*/include ${libdir}/erlang/lib/ic-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-ic-staticdev="1"
+DESCRIPTION_${PN}-ic-staticdev=""
+RDEPENDS_${PN}-ic-staticdev=""
+FILES_${PN}-ic-staticdev="${libdir}/erlang/lib/ic-*/lib/*.a ${libdir}/erlang/lib/ic-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-ic="1"
+DESCRIPTION_${PN}-ic=""
+RDEPENDS_${PN}-ic=""
+FILES_${PN}-ic="${libdir}/erlang/lib/ic-* "
+
+ALLOW_EMPTY_${PN}-inets-doc="1"
+DESCRIPTION_${PN}-inets-doc=""
+RDEPENDS_${PN}-inets-doc=""
+FILES_${PN}-inets-doc="${libdir}/erlang/lib/inets-*/examples ${libdir}/erlang/lib/inets-*/doc ${libdir}/erlang/lib/inets-*/man "
+
+ALLOW_EMPTY_${PN}-inets-dbg="1"
+DESCRIPTION_${PN}-inets-dbg=""
+RDEPENDS_${PN}-inets-dbg=""
+FILES_${PN}-inets-dbg="${libdir}/erlang/lib/inets-*/bin/.debug ${libdir}/erlang/lib/inets-*/lib/.debug ${libdir}/erlang/lib/inets-*/priv/lib/.debug ${libdir}/erlang/lib/inets-*/priv/obj/.debug ${libdir}/erlang/lib/inets-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-inets-dev="1"
+DESCRIPTION_${PN}-inets-dev=""
+RDEPENDS_${PN}-inets-dev=""
+FILES_${PN}-inets-dev="${libdir}/erlang/lib/inets-*/*src ${libdir}/erlang/lib/inets-*/include ${libdir}/erlang/lib/inets-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-inets-staticdev="1"
+DESCRIPTION_${PN}-inets-staticdev=""
+RDEPENDS_${PN}-inets-staticdev=""
+FILES_${PN}-inets-staticdev="${libdir}/erlang/lib/inets-*/lib/*.a ${libdir}/erlang/lib/inets-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-inets="1"
+DESCRIPTION_${PN}-inets=""
+RDEPENDS_${PN}-inets=""
+FILES_${PN}-inets="${libdir}/erlang/lib/inets-* "
+
+ALLOW_EMPTY_${PN}-jinterface-doc="1"
+DESCRIPTION_${PN}-jinterface-doc=""
+RDEPENDS_${PN}-jinterface-doc=""
+FILES_${PN}-jinterface-doc="${libdir}/erlang/lib/jinterface-*/examples ${libdir}/erlang/lib/jinterface-*/doc ${libdir}/erlang/lib/jinterface-*/man "
+
+ALLOW_EMPTY_${PN}-jinterface-dbg="1"
+DESCRIPTION_${PN}-jinterface-dbg=""
+RDEPENDS_${PN}-jinterface-dbg=""
+FILES_${PN}-jinterface-dbg="${libdir}/erlang/lib/jinterface-*/bin/.debug ${libdir}/erlang/lib/jinterface-*/lib/.debug ${libdir}/erlang/lib/jinterface-*/priv/lib/.debug ${libdir}/erlang/lib/jinterface-*/priv/obj/.debug ${libdir}/erlang/lib/jinterface-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-jinterface-dev="1"
+DESCRIPTION_${PN}-jinterface-dev=""
+RDEPENDS_${PN}-jinterface-dev=""
+FILES_${PN}-jinterface-dev="${libdir}/erlang/lib/jinterface-*/*src ${libdir}/erlang/lib/jinterface-*/include ${libdir}/erlang/lib/jinterface-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-jinterface-staticdev="1"
+DESCRIPTION_${PN}-jinterface-staticdev=""
+RDEPENDS_${PN}-jinterface-staticdev=""
+FILES_${PN}-jinterface-staticdev="${libdir}/erlang/lib/jinterface-*/lib/*.a ${libdir}/erlang/lib/jinterface-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-jinterface="1"
+DESCRIPTION_${PN}-jinterface=""
+RDEPENDS_${PN}-jinterface=""
+FILES_${PN}-jinterface="${libdir}/erlang/lib/jinterface-* "
+
+ALLOW_EMPTY_${PN}-megaco-doc="1"
+DESCRIPTION_${PN}-megaco-doc=""
+RDEPENDS_${PN}-megaco-doc=""
+FILES_${PN}-megaco-doc="${libdir}/erlang/lib/megaco-*/examples ${libdir}/erlang/lib/megaco-*/doc ${libdir}/erlang/lib/megaco-*/man "
+
+ALLOW_EMPTY_${PN}-megaco-dbg="1"
+DESCRIPTION_${PN}-megaco-dbg=""
+RDEPENDS_${PN}-megaco-dbg=""
+FILES_${PN}-megaco-dbg="${libdir}/erlang/lib/megaco-*/bin/.debug ${libdir}/erlang/lib/megaco-*/lib/.debug ${libdir}/erlang/lib/megaco-*/priv/lib/.debug ${libdir}/erlang/lib/megaco-*/priv/obj/.debug ${libdir}/erlang/lib/megaco-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-megaco-dev="1"
+DESCRIPTION_${PN}-megaco-dev=""
+RDEPENDS_${PN}-megaco-dev=""
+FILES_${PN}-megaco-dev="${libdir}/erlang/lib/megaco-*/*src ${libdir}/erlang/lib/megaco-*/include ${libdir}/erlang/lib/megaco-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-megaco-staticdev="1"
+DESCRIPTION_${PN}-megaco-staticdev=""
+RDEPENDS_${PN}-megaco-staticdev=""
+FILES_${PN}-megaco-staticdev="${libdir}/erlang/lib/megaco-*/lib/*.a ${libdir}/erlang/lib/megaco-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-megaco="1"
+DESCRIPTION_${PN}-megaco=""
+RDEPENDS_${PN}-megaco=""
+FILES_${PN}-megaco="${libdir}/erlang/lib/megaco-* "
+
+ALLOW_EMPTY_${PN}-mnesia-doc="1"
+DESCRIPTION_${PN}-mnesia-doc=""
+RDEPENDS_${PN}-mnesia-doc=""
+FILES_${PN}-mnesia-doc="${libdir}/erlang/lib/mnesia-*/examples ${libdir}/erlang/lib/mnesia-*/doc ${libdir}/erlang/lib/mnesia-*/man "
+
+ALLOW_EMPTY_${PN}-mnesia-dbg="1"
+DESCRIPTION_${PN}-mnesia-dbg=""
+RDEPENDS_${PN}-mnesia-dbg=""
+FILES_${PN}-mnesia-dbg="${libdir}/erlang/lib/mnesia-*/bin/.debug ${libdir}/erlang/lib/mnesia-*/lib/.debug ${libdir}/erlang/lib/mnesia-*/priv/lib/.debug ${libdir}/erlang/lib/mnesia-*/priv/obj/.debug ${libdir}/erlang/lib/mnesia-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-mnesia-dev="1"
+DESCRIPTION_${PN}-mnesia-dev=""
+RDEPENDS_${PN}-mnesia-dev=""
+FILES_${PN}-mnesia-dev="${libdir}/erlang/lib/mnesia-*/*src ${libdir}/erlang/lib/mnesia-*/include ${libdir}/erlang/lib/mnesia-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-mnesia-staticdev="1"
+DESCRIPTION_${PN}-mnesia-staticdev=""
+RDEPENDS_${PN}-mnesia-staticdev=""
+FILES_${PN}-mnesia-staticdev="${libdir}/erlang/lib/mnesia-*/lib/*.a ${libdir}/erlang/lib/mnesia-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-mnesia="1"
+DESCRIPTION_${PN}-mnesia=""
+RDEPENDS_${PN}-mnesia=""
+FILES_${PN}-mnesia="${libdir}/erlang/lib/mnesia-* "
+
+ALLOW_EMPTY_${PN}-observer-doc="1"
+DESCRIPTION_${PN}-observer-doc=""
+RDEPENDS_${PN}-observer-doc=""
+FILES_${PN}-observer-doc="${libdir}/erlang/lib/observer-*/examples ${libdir}/erlang/lib/observer-*/doc ${libdir}/erlang/lib/observer-*/man "
+
+ALLOW_EMPTY_${PN}-observer-dbg="1"
+DESCRIPTION_${PN}-observer-dbg=""
+RDEPENDS_${PN}-observer-dbg=""
+FILES_${PN}-observer-dbg="${libdir}/erlang/lib/observer-*/bin/.debug ${libdir}/erlang/lib/observer-*/lib/.debug ${libdir}/erlang/lib/observer-*/priv/lib/.debug ${libdir}/erlang/lib/observer-*/priv/obj/.debug ${libdir}/erlang/lib/observer-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-observer-dev="1"
+DESCRIPTION_${PN}-observer-dev=""
+RDEPENDS_${PN}-observer-dev=""
+FILES_${PN}-observer-dev="${libdir}/erlang/lib/observer-*/*src ${libdir}/erlang/lib/observer-*/include ${libdir}/erlang/lib/observer-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-observer-staticdev="1"
+DESCRIPTION_${PN}-observer-staticdev=""
+RDEPENDS_${PN}-observer-staticdev=""
+FILES_${PN}-observer-staticdev="${libdir}/erlang/lib/observer-*/lib/*.a ${libdir}/erlang/lib/observer-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-observer="1"
+DESCRIPTION_${PN}-observer=""
+RDEPENDS_${PN}-observer=""
+FILES_${PN}-observer="${libdir}/erlang/lib/observer-* "
+
+ALLOW_EMPTY_${PN}-orber-doc="1"
+DESCRIPTION_${PN}-orber-doc=""
+RDEPENDS_${PN}-orber-doc=""
+FILES_${PN}-orber-doc="${libdir}/erlang/lib/orber-*/examples ${libdir}/erlang/lib/orber-*/doc ${libdir}/erlang/lib/orber-*/man "
+
+ALLOW_EMPTY_${PN}-orber-dbg="1"
+DESCRIPTION_${PN}-orber-dbg=""
+RDEPENDS_${PN}-orber-dbg=""
+FILES_${PN}-orber-dbg="${libdir}/erlang/lib/orber-*/bin/.debug ${libdir}/erlang/lib/orber-*/lib/.debug ${libdir}/erlang/lib/orber-*/priv/lib/.debug ${libdir}/erlang/lib/orber-*/priv/obj/.debug ${libdir}/erlang/lib/orber-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-orber-dev="1"
+DESCRIPTION_${PN}-orber-dev=""
+RDEPENDS_${PN}-orber-dev=""
+FILES_${PN}-orber-dev="${libdir}/erlang/lib/orber-*/*src ${libdir}/erlang/lib/orber-*/include ${libdir}/erlang/lib/orber-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-orber-staticdev="1"
+DESCRIPTION_${PN}-orber-staticdev=""
+RDEPENDS_${PN}-orber-staticdev=""
+FILES_${PN}-orber-staticdev="${libdir}/erlang/lib/orber-*/lib/*.a ${libdir}/erlang/lib/orber-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-orber="1"
+DESCRIPTION_${PN}-orber=""
+RDEPENDS_${PN}-orber=""
+FILES_${PN}-orber="${libdir}/erlang/lib/orber-* "
+
+ALLOW_EMPTY_${PN}-os-mon-doc="1"
+DESCRIPTION_${PN}-os-mon-doc=""
+RDEPENDS_${PN}-os-mon-doc=""
+FILES_${PN}-os-mon-doc="${libdir}/erlang/lib/os-mon-*/examples ${libdir}/erlang/lib/os-mon-*/doc ${libdir}/erlang/lib/os-mon-*/man "
+
+ALLOW_EMPTY_${PN}-os-mon-dbg="1"
+DESCRIPTION_${PN}-os-mon-dbg=""
+RDEPENDS_${PN}-os-mon-dbg=""
+FILES_${PN}-os-mon-dbg="${libdir}/erlang/lib/os_mon-*/bin/.debug ${libdir}/erlang/lib/os_mon-*/lib/.debug ${libdir}/erlang/lib/os_mon-*/priv/lib/.debug ${libdir}/erlang/lib/os_mon-*/priv/obj/.debug ${libdir}/erlang/lib/os_mon-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-os-mon-dev="1"
+DESCRIPTION_${PN}-os-mon-dev=""
+RDEPENDS_${PN}-os-mon-dev=""
+FILES_${PN}-os-mon-dev="${libdir}/erlang/lib/os_mon-*/*src ${libdir}/erlang/lib/os_mon-*/include ${libdir}/erlang/lib/os_mon-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-os-mon-staticdev="1"
+DESCRIPTION_${PN}-os-mon-staticdev=""
+RDEPENDS_${PN}-os-mon-staticdev=""
+FILES_${PN}-os-mon-staticdev="${libdir}/erlang/lib/os_mon-*/lib/*.a ${libdir}/erlang/lib/os_mon-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-os-mon="1"
+DESCRIPTION_${PN}-os-mon=""
+RDEPENDS_${PN}-os-mon=""
+FILES_${PN}-os-mon="${libdir}/erlang/lib/os_mon-* "
+
+ALLOW_EMPTY_${PN}-otp-mibs-doc="1"
+DESCRIPTION_${PN}-otp-mibs-doc=""
+RDEPENDS_${PN}-otp-mibs-doc=""
+FILES_${PN}-otp-mibs-doc="${libdir}/erlang/lib/otp-mibs-*/examples ${libdir}/erlang/lib/otp-mibs-*/doc ${libdir}/erlang/lib/otp-mibs-*/man "
+
+ALLOW_EMPTY_${PN}-otp-mibs-dbg="1"
+DESCRIPTION_${PN}-otp-mibs-dbg=""
+RDEPENDS_${PN}-otp-mibs-dbg=""
+FILES_${PN}-otp-mibs-dbg="${libdir}/erlang/lib/otp_mibs-*/bin/.debug ${libdir}/erlang/lib/otp_mibs-*/lib/.debug ${libdir}/erlang/lib/otp_mibs-*/priv/lib/.debug ${libdir}/erlang/lib/otp_mibs-*/priv/obj/.debug ${libdir}/erlang/lib/otp_mibs-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-otp-mibs-dev="1"
+DESCRIPTION_${PN}-otp-mibs-dev=""
+RDEPENDS_${PN}-otp-mibs-dev=""
+FILES_${PN}-otp-mibs-dev="${libdir}/erlang/lib/otp_mibs-*/*src ${libdir}/erlang/lib/otp_mibs-*/include ${libdir}/erlang/lib/otp_mibs-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-otp-mibs-staticdev="1"
+DESCRIPTION_${PN}-otp-mibs-staticdev=""
+RDEPENDS_${PN}-otp-mibs-staticdev=""
+FILES_${PN}-otp-mibs-staticdev="${libdir}/erlang/lib/otp_mibs-*/lib/*.a ${libdir}/erlang/lib/otp_mibs-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-otp-mibs="1"
+DESCRIPTION_${PN}-otp-mibs=""
+RDEPENDS_${PN}-otp-mibs=""
+FILES_${PN}-otp-mibs="${libdir}/erlang/lib/otp_mibs-* "
+
+ALLOW_EMPTY_${PN}-parsetools-doc="1"
+DESCRIPTION_${PN}-parsetools-doc=""
+RDEPENDS_${PN}-parsetools-doc=""
+FILES_${PN}-parsetools-doc="${libdir}/erlang/lib/parsetools-*/examples ${libdir}/erlang/lib/parsetools-*/doc ${libdir}/erlang/lib/parsetools-*/man "
+
+ALLOW_EMPTY_${PN}-parsetools-dbg="1"
+DESCRIPTION_${PN}-parsetools-dbg=""
+RDEPENDS_${PN}-parsetools-dbg=""
+FILES_${PN}-parsetools-dbg="${libdir}/erlang/lib/parsetools-*/bin/.debug ${libdir}/erlang/lib/parsetools-*/lib/.debug ${libdir}/erlang/lib/parsetools-*/priv/lib/.debug ${libdir}/erlang/lib/parsetools-*/priv/obj/.debug ${libdir}/erlang/lib/parsetools-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-parsetools-dev="1"
+DESCRIPTION_${PN}-parsetools-dev=""
+RDEPENDS_${PN}-parsetools-dev=""
+FILES_${PN}-parsetools-dev="${libdir}/erlang/lib/parsetools-*/*src ${libdir}/erlang/lib/parsetools-*/include ${libdir}/erlang/lib/parsetools-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-parsetools-staticdev="1"
+DESCRIPTION_${PN}-parsetools-staticdev=""
+RDEPENDS_${PN}-parsetools-staticdev=""
+FILES_${PN}-parsetools-staticdev="${libdir}/erlang/lib/parsetools-*/lib/*.a ${libdir}/erlang/lib/parsetools-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-parsetools="1"
+DESCRIPTION_${PN}-parsetools=""
+RDEPENDS_${PN}-parsetools=""
+FILES_${PN}-parsetools="${libdir}/erlang/lib/parsetools-* "
+
+ALLOW_EMPTY_${PN}-percept-doc="1"
+DESCRIPTION_${PN}-percept-doc=""
+RDEPENDS_${PN}-percept-doc=""
+FILES_${PN}-percept-doc="${libdir}/erlang/lib/percept-*/examples ${libdir}/erlang/lib/percept-*/doc ${libdir}/erlang/lib/percept-*/man "
+
+ALLOW_EMPTY_${PN}-percept-dbg="1"
+DESCRIPTION_${PN}-percept-dbg=""
+RDEPENDS_${PN}-percept-dbg=""
+FILES_${PN}-percept-dbg="${libdir}/erlang/lib/percept-*/bin/.debug ${libdir}/erlang/lib/percept-*/lib/.debug ${libdir}/erlang/lib/percept-*/priv/lib/.debug ${libdir}/erlang/lib/percept-*/priv/obj/.debug ${libdir}/erlang/lib/percept-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-percept-dev="1"
+DESCRIPTION_${PN}-percept-dev=""
+RDEPENDS_${PN}-percept-dev=""
+FILES_${PN}-percept-dev="${libdir}/erlang/lib/percept-*/*src ${libdir}/erlang/lib/percept-*/include ${libdir}/erlang/lib/percept-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-percept-staticdev="1"
+DESCRIPTION_${PN}-percept-staticdev=""
+RDEPENDS_${PN}-percept-staticdev=""
+FILES_${PN}-percept-staticdev="${libdir}/erlang/lib/percept-*/lib/*.a ${libdir}/erlang/lib/percept-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-percept="1"
+DESCRIPTION_${PN}-percept=""
+RDEPENDS_${PN}-percept=""
+FILES_${PN}-percept="${libdir}/erlang/lib/percept-* "
+
+ALLOW_EMPTY_${PN}-pman-doc="1"
+DESCRIPTION_${PN}-pman-doc=""
+RDEPENDS_${PN}-pman-doc=""
+FILES_${PN}-pman-doc="${libdir}/erlang/lib/pman-*/examples ${libdir}/erlang/lib/pman-*/doc ${libdir}/erlang/lib/pman-*/man "
+
+ALLOW_EMPTY_${PN}-pman-dbg="1"
+DESCRIPTION_${PN}-pman-dbg=""
+RDEPENDS_${PN}-pman-dbg=""
+FILES_${PN}-pman-dbg="${libdir}/erlang/lib/pman-*/bin/.debug ${libdir}/erlang/lib/pman-*/lib/.debug ${libdir}/erlang/lib/pman-*/priv/lib/.debug ${libdir}/erlang/lib/pman-*/priv/obj/.debug ${libdir}/erlang/lib/pman-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-pman-dev="1"
+DESCRIPTION_${PN}-pman-dev=""
+RDEPENDS_${PN}-pman-dev=""
+FILES_${PN}-pman-dev="${libdir}/erlang/lib/pman-*/*src ${libdir}/erlang/lib/pman-*/include ${libdir}/erlang/lib/pman-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-pman-staticdev="1"
+DESCRIPTION_${PN}-pman-staticdev=""
+RDEPENDS_${PN}-pman-staticdev=""
+FILES_${PN}-pman-staticdev="${libdir}/erlang/lib/pman-*/lib/*.a ${libdir}/erlang/lib/pman-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-pman="1"
+DESCRIPTION_${PN}-pman=""
+RDEPENDS_${PN}-pman=""
+FILES_${PN}-pman="${libdir}/erlang/lib/pman-* "
+
+ALLOW_EMPTY_${PN}-public-key-doc="1"
+DESCRIPTION_${PN}-public-key-doc=""
+RDEPENDS_${PN}-public-key-doc=""
+FILES_${PN}-public-key-doc="${libdir}/erlang/lib/public-key-*/examples ${libdir}/erlang/lib/public-key-*/doc ${libdir}/erlang/lib/public-key-*/man "
+
+ALLOW_EMPTY_${PN}-public-key-dbg="1"
+DESCRIPTION_${PN}-public-key-dbg=""
+RDEPENDS_${PN}-public-key-dbg=""
+FILES_${PN}-public-key-dbg="${libdir}/erlang/lib/public_key-*/bin/.debug ${libdir}/erlang/lib/public_key-*/lib/.debug ${libdir}/erlang/lib/public_key-*/priv/lib/.debug ${libdir}/erlang/lib/public_key-*/priv/obj/.debug ${libdir}/erlang/lib/public_key-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-public-key-dev="1"
+DESCRIPTION_${PN}-public-key-dev=""
+RDEPENDS_${PN}-public-key-dev=""
+FILES_${PN}-public-key-dev="${libdir}/erlang/lib/public_key-*/*src ${libdir}/erlang/lib/public_key-*/include ${libdir}/erlang/lib/public_key-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-public-key-staticdev="1"
+DESCRIPTION_${PN}-public-key-staticdev=""
+RDEPENDS_${PN}-public-key-staticdev=""
+FILES_${PN}-public-key-staticdev="${libdir}/erlang/lib/public_key-*/lib/*.a ${libdir}/erlang/lib/public_key-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-public-key="1"
+DESCRIPTION_${PN}-public-key=""
+RDEPENDS_${PN}-public-key=""
+FILES_${PN}-public-key="${libdir}/erlang/lib/public_key-* "
+
+ALLOW_EMPTY_${PN}-reltool-doc="1"
+DESCRIPTION_${PN}-reltool-doc=""
+RDEPENDS_${PN}-reltool-doc=""
+FILES_${PN}-reltool-doc="${libdir}/erlang/lib/reltool-*/examples ${libdir}/erlang/lib/reltool-*/doc ${libdir}/erlang/lib/reltool-*/man "
+
+ALLOW_EMPTY_${PN}-reltool-dbg="1"
+DESCRIPTION_${PN}-reltool-dbg=""
+RDEPENDS_${PN}-reltool-dbg=""
+FILES_${PN}-reltool-dbg="${libdir}/erlang/lib/reltool-*/bin/.debug ${libdir}/erlang/lib/reltool-*/lib/.debug ${libdir}/erlang/lib/reltool-*/priv/lib/.debug ${libdir}/erlang/lib/reltool-*/priv/obj/.debug ${libdir}/erlang/lib/reltool-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-reltool-dev="1"
+DESCRIPTION_${PN}-reltool-dev=""
+RDEPENDS_${PN}-reltool-dev=""
+FILES_${PN}-reltool-dev="${libdir}/erlang/lib/reltool-*/*src ${libdir}/erlang/lib/reltool-*/include ${libdir}/erlang/lib/reltool-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-reltool-staticdev="1"
+DESCRIPTION_${PN}-reltool-staticdev=""
+RDEPENDS_${PN}-reltool-staticdev=""
+FILES_${PN}-reltool-staticdev="${libdir}/erlang/lib/reltool-*/lib/*.a ${libdir}/erlang/lib/reltool-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-reltool="1"
+DESCRIPTION_${PN}-reltool=""
+RDEPENDS_${PN}-reltool=""
+FILES_${PN}-reltool="${libdir}/erlang/lib/reltool-* "
+
+ALLOW_EMPTY_${PN}-runtime-tools-doc="1"
+DESCRIPTION_${PN}-runtime-tools-doc=""
+RDEPENDS_${PN}-runtime-tools-doc=""
+FILES_${PN}-runtime-tools-doc="${libdir}/erlang/lib/runtime-tools-*/examples ${libdir}/erlang/lib/runtime-tools-*/doc ${libdir}/erlang/lib/runtime-tools-*/man "
+
+ALLOW_EMPTY_${PN}-runtime-tools-dbg="1"
+DESCRIPTION_${PN}-runtime-tools-dbg=""
+RDEPENDS_${PN}-runtime-tools-dbg=""
+FILES_${PN}-runtime-tools-dbg="${libdir}/erlang/lib/runtime_tools-*/bin/.debug ${libdir}/erlang/lib/runtime_tools-*/lib/.debug ${libdir}/erlang/lib/runtime_tools-*/priv/lib/.debug ${libdir}/erlang/lib/runtime_tools-*/priv/obj/.debug ${libdir}/erlang/lib/runtime_tools-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-runtime-tools-dev="1"
+DESCRIPTION_${PN}-runtime-tools-dev=""
+RDEPENDS_${PN}-runtime-tools-dev=""
+FILES_${PN}-runtime-tools-dev="${libdir}/erlang/lib/runtime_tools-*/*src ${libdir}/erlang/lib/runtime_tools-*/include ${libdir}/erlang/lib/runtime_tools-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-runtime-tools-staticdev="1"
+DESCRIPTION_${PN}-runtime-tools-staticdev=""
+RDEPENDS_${PN}-runtime-tools-staticdev=""
+FILES_${PN}-runtime-tools-staticdev="${libdir}/erlang/lib/runtime_tools-*/lib/*.a ${libdir}/erlang/lib/runtime_tools-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-runtime-tools="1"
+DESCRIPTION_${PN}-runtime-tools=""
+RDEPENDS_${PN}-runtime-tools=""
+FILES_${PN}-runtime-tools="${libdir}/erlang/lib/runtime_tools-* "
+
+ALLOW_EMPTY_${PN}-snmp-doc="1"
+DESCRIPTION_${PN}-snmp-doc=""
+RDEPENDS_${PN}-snmp-doc=""
+FILES_${PN}-snmp-doc="${libdir}/erlang/lib/snmp-*/examples ${libdir}/erlang/lib/snmp-*/doc ${libdir}/erlang/lib/snmp-*/man "
+
+ALLOW_EMPTY_${PN}-snmp-dbg="1"
+DESCRIPTION_${PN}-snmp-dbg=""
+RDEPENDS_${PN}-snmp-dbg=""
+FILES_${PN}-snmp-dbg="${libdir}/erlang/lib/snmp-*/bin/.debug ${libdir}/erlang/lib/snmp-*/lib/.debug ${libdir}/erlang/lib/snmp-*/priv/lib/.debug ${libdir}/erlang/lib/snmp-*/priv/obj/.debug ${libdir}/erlang/lib/snmp-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-snmp-dev="1"
+DESCRIPTION_${PN}-snmp-dev=""
+RDEPENDS_${PN}-snmp-dev=""
+FILES_${PN}-snmp-dev="${libdir}/erlang/lib/snmp-*/*src ${libdir}/erlang/lib/snmp-*/include ${libdir}/erlang/lib/snmp-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-snmp-staticdev="1"
+DESCRIPTION_${PN}-snmp-staticdev=""
+RDEPENDS_${PN}-snmp-staticdev=""
+FILES_${PN}-snmp-staticdev="${libdir}/erlang/lib/snmp-*/lib/*.a ${libdir}/erlang/lib/snmp-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-snmp="1"
+DESCRIPTION_${PN}-snmp=""
+RDEPENDS_${PN}-snmp=""
+FILES_${PN}-snmp="${libdir}/erlang/lib/snmp-* "
+
+ALLOW_EMPTY_${PN}-ssh-doc="1"
+DESCRIPTION_${PN}-ssh-doc=""
+RDEPENDS_${PN}-ssh-doc=""
+FILES_${PN}-ssh-doc="${libdir}/erlang/lib/ssh-*/examples ${libdir}/erlang/lib/ssh-*/doc ${libdir}/erlang/lib/ssh-*/man "
+
+ALLOW_EMPTY_${PN}-ssh-dbg="1"
+DESCRIPTION_${PN}-ssh-dbg=""
+RDEPENDS_${PN}-ssh-dbg=""
+FILES_${PN}-ssh-dbg="${libdir}/erlang/lib/ssh-*/bin/.debug ${libdir}/erlang/lib/ssh-*/lib/.debug ${libdir}/erlang/lib/ssh-*/priv/lib/.debug ${libdir}/erlang/lib/ssh-*/priv/obj/.debug ${libdir}/erlang/lib/ssh-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-ssh-dev="1"
+DESCRIPTION_${PN}-ssh-dev=""
+RDEPENDS_${PN}-ssh-dev=""
+FILES_${PN}-ssh-dev="${libdir}/erlang/lib/ssh-*/*src ${libdir}/erlang/lib/ssh-*/include ${libdir}/erlang/lib/ssh-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-ssh-staticdev="1"
+DESCRIPTION_${PN}-ssh-staticdev=""
+RDEPENDS_${PN}-ssh-staticdev=""
+FILES_${PN}-ssh-staticdev="${libdir}/erlang/lib/ssh-*/lib/*.a ${libdir}/erlang/lib/ssh-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-ssh="1"
+DESCRIPTION_${PN}-ssh=""
+RDEPENDS_${PN}-ssh=""
+FILES_${PN}-ssh="${libdir}/erlang/lib/ssh-* "
+
+ALLOW_EMPTY_${PN}-ssl-doc="1"
+DESCRIPTION_${PN}-ssl-doc=""
+RDEPENDS_${PN}-ssl-doc=""
+FILES_${PN}-ssl-doc="${libdir}/erlang/lib/ssl-*/examples ${libdir}/erlang/lib/ssl-*/doc ${libdir}/erlang/lib/ssl-*/man "
+
+ALLOW_EMPTY_${PN}-ssl-dbg="1"
+DESCRIPTION_${PN}-ssl-dbg=""
+RDEPENDS_${PN}-ssl-dbg=""
+FILES_${PN}-ssl-dbg="${libdir}/erlang/lib/ssl-*/bin/.debug ${libdir}/erlang/lib/ssl-*/lib/.debug ${libdir}/erlang/lib/ssl-*/priv/lib/.debug ${libdir}/erlang/lib/ssl-*/priv/obj/.debug ${libdir}/erlang/lib/ssl-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-ssl-dev="1"
+DESCRIPTION_${PN}-ssl-dev=""
+RDEPENDS_${PN}-ssl-dev=""
+FILES_${PN}-ssl-dev="${libdir}/erlang/lib/ssl-*/*src ${libdir}/erlang/lib/ssl-*/include ${libdir}/erlang/lib/ssl-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-ssl-staticdev="1"
+DESCRIPTION_${PN}-ssl-staticdev=""
+RDEPENDS_${PN}-ssl-staticdev=""
+FILES_${PN}-ssl-staticdev="${libdir}/erlang/lib/ssl-*/lib/*.a ${libdir}/erlang/lib/ssl-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-ssl="1"
+DESCRIPTION_${PN}-ssl=""
+RDEPENDS_${PN}-ssl=""
+FILES_${PN}-ssl="${libdir}/erlang/lib/ssl-* "
+
+ALLOW_EMPTY_${PN}-syntax-tools-doc="1"
+DESCRIPTION_${PN}-syntax-tools-doc=""
+RDEPENDS_${PN}-syntax-tools-doc=""
+FILES_${PN}-syntax-tools-doc="${libdir}/erlang/lib/syntax-tools-*/examples ${libdir}/erlang/lib/syntax-tools-*/doc ${libdir}/erlang/lib/syntax-tools-*/man "
+
+ALLOW_EMPTY_${PN}-syntax-tools-dbg="1"
+DESCRIPTION_${PN}-syntax-tools-dbg=""
+RDEPENDS_${PN}-syntax-tools-dbg=""
+FILES_${PN}-syntax-tools-dbg="${libdir}/erlang/lib/syntax_tools-*/bin/.debug ${libdir}/erlang/lib/syntax_tools-*/lib/.debug ${libdir}/erlang/lib/syntax_tools-*/priv/lib/.debug ${libdir}/erlang/lib/syntax_tools-*/priv/obj/.debug ${libdir}/erlang/lib/syntax_tools-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-syntax-tools-dev="1"
+DESCRIPTION_${PN}-syntax-tools-dev=""
+RDEPENDS_${PN}-syntax-tools-dev=""
+FILES_${PN}-syntax-tools-dev="${libdir}/erlang/lib/syntax_tools-*/*src ${libdir}/erlang/lib/syntax_tools-*/include ${libdir}/erlang/lib/syntax_tools-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-syntax-tools-staticdev="1"
+DESCRIPTION_${PN}-syntax-tools-staticdev=""
+RDEPENDS_${PN}-syntax-tools-staticdev=""
+FILES_${PN}-syntax-tools-staticdev="${libdir}/erlang/lib/syntax_tools-*/lib/*.a ${libdir}/erlang/lib/syntax_tools-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-syntax-tools="1"
+DESCRIPTION_${PN}-syntax-tools=""
+RDEPENDS_${PN}-syntax-tools=""
+FILES_${PN}-syntax-tools="${libdir}/erlang/lib/syntax_tools-* "
+
+ALLOW_EMPTY_${PN}-test-server-doc="1"
+DESCRIPTION_${PN}-test-server-doc=""
+RDEPENDS_${PN}-test-server-doc=""
+FILES_${PN}-test-server-doc="${libdir}/erlang/lib/test-server-*/examples ${libdir}/erlang/lib/test-server-*/doc ${libdir}/erlang/lib/test-server-*/man "
+
+ALLOW_EMPTY_${PN}-test-server-dbg="1"
+DESCRIPTION_${PN}-test-server-dbg=""
+RDEPENDS_${PN}-test-server-dbg=""
+FILES_${PN}-test-server-dbg="${libdir}/erlang/lib/test_server-*/bin/.debug ${libdir}/erlang/lib/test_server-*/lib/.debug ${libdir}/erlang/lib/test_server-*/priv/lib/.debug ${libdir}/erlang/lib/test_server-*/priv/obj/.debug ${libdir}/erlang/lib/test_server-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-test-server-dev="1"
+DESCRIPTION_${PN}-test-server-dev=""
+RDEPENDS_${PN}-test-server-dev=""
+FILES_${PN}-test-server-dev="${libdir}/erlang/lib/test_server-*/*src ${libdir}/erlang/lib/test_server-*/include ${libdir}/erlang/lib/test_server-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-test-server-staticdev="1"
+DESCRIPTION_${PN}-test-server-staticdev=""
+RDEPENDS_${PN}-test-server-staticdev=""
+FILES_${PN}-test-server-staticdev="${libdir}/erlang/lib/test_server-*/lib/*.a ${libdir}/erlang/lib/test_server-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-test-server="1"
+DESCRIPTION_${PN}-test-server=""
+RDEPENDS_${PN}-test-server=""
+FILES_${PN}-test-server="${libdir}/erlang/lib/test_server-* "
+
+ALLOW_EMPTY_${PN}-toolbar-doc="1"
+DESCRIPTION_${PN}-toolbar-doc=""
+RDEPENDS_${PN}-toolbar-doc=""
+FILES_${PN}-toolbar-doc="${libdir}/erlang/lib/toolbar-*/examples ${libdir}/erlang/lib/toolbar-*/doc ${libdir}/erlang/lib/toolbar-*/man "
+
+ALLOW_EMPTY_${PN}-toolbar-dbg="1"
+DESCRIPTION_${PN}-toolbar-dbg=""
+RDEPENDS_${PN}-toolbar-dbg=""
+FILES_${PN}-toolbar-dbg="${libdir}/erlang/lib/toolbar-*/bin/.debug ${libdir}/erlang/lib/toolbar-*/lib/.debug ${libdir}/erlang/lib/toolbar-*/priv/lib/.debug ${libdir}/erlang/lib/toolbar-*/priv/obj/.debug ${libdir}/erlang/lib/toolbar-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-toolbar-dev="1"
+DESCRIPTION_${PN}-toolbar-dev=""
+RDEPENDS_${PN}-toolbar-dev=""
+FILES_${PN}-toolbar-dev="${libdir}/erlang/lib/toolbar-*/*src ${libdir}/erlang/lib/toolbar-*/include ${libdir}/erlang/lib/toolbar-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-toolbar-staticdev="1"
+DESCRIPTION_${PN}-toolbar-staticdev=""
+RDEPENDS_${PN}-toolbar-staticdev=""
+FILES_${PN}-toolbar-staticdev="${libdir}/erlang/lib/toolbar-*/lib/*.a ${libdir}/erlang/lib/toolbar-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-toolbar="1"
+DESCRIPTION_${PN}-toolbar=""
+RDEPENDS_${PN}-toolbar=""
+FILES_${PN}-toolbar="${libdir}/erlang/lib/toolbar-* "
+
+ALLOW_EMPTY_${PN}-tv-doc="1"
+DESCRIPTION_${PN}-tv-doc=""
+RDEPENDS_${PN}-tv-doc=""
+FILES_${PN}-tv-doc="${libdir}/erlang/lib/tv-*/examples ${libdir}/erlang/lib/tv-*/doc ${libdir}/erlang/lib/tv-*/man "
+
+ALLOW_EMPTY_${PN}-tv-dbg="1"
+DESCRIPTION_${PN}-tv-dbg=""
+RDEPENDS_${PN}-tv-dbg=""
+FILES_${PN}-tv-dbg="${libdir}/erlang/lib/tv-*/bin/.debug ${libdir}/erlang/lib/tv-*/lib/.debug ${libdir}/erlang/lib/tv-*/priv/lib/.debug ${libdir}/erlang/lib/tv-*/priv/obj/.debug ${libdir}/erlang/lib/tv-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-tv-dev="1"
+DESCRIPTION_${PN}-tv-dev=""
+RDEPENDS_${PN}-tv-dev=""
+FILES_${PN}-tv-dev="${libdir}/erlang/lib/tv-*/*src ${libdir}/erlang/lib/tv-*/include ${libdir}/erlang/lib/tv-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-tv-staticdev="1"
+DESCRIPTION_${PN}-tv-staticdev=""
+RDEPENDS_${PN}-tv-staticdev=""
+FILES_${PN}-tv-staticdev="${libdir}/erlang/lib/tv-*/lib/*.a ${libdir}/erlang/lib/tv-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-tv="1"
+DESCRIPTION_${PN}-tv=""
+RDEPENDS_${PN}-tv=""
+FILES_${PN}-tv="${libdir}/erlang/lib/tv-* "
+
+ALLOW_EMPTY_${PN}-typer-doc="1"
+DESCRIPTION_${PN}-typer-doc=""
+RDEPENDS_${PN}-typer-doc=""
+FILES_${PN}-typer-doc="${libdir}/erlang/lib/typer-*/examples ${libdir}/erlang/lib/typer-*/doc ${libdir}/erlang/lib/typer-*/man "
+
+ALLOW_EMPTY_${PN}-typer-dbg="1"
+DESCRIPTION_${PN}-typer-dbg=""
+RDEPENDS_${PN}-typer-dbg=""
+FILES_${PN}-typer-dbg="${libdir}/erlang/lib/typer-*/bin/.debug ${libdir}/erlang/lib/typer-*/lib/.debug ${libdir}/erlang/lib/typer-*/priv/lib/.debug ${libdir}/erlang/lib/typer-*/priv/obj/.debug ${libdir}/erlang/lib/typer-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-typer-dev="1"
+DESCRIPTION_${PN}-typer-dev=""
+RDEPENDS_${PN}-typer-dev=""
+FILES_${PN}-typer-dev="${libdir}/erlang/lib/typer-*/*src ${libdir}/erlang/lib/typer-*/include ${libdir}/erlang/lib/typer-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-typer-staticdev="1"
+DESCRIPTION_${PN}-typer-staticdev=""
+RDEPENDS_${PN}-typer-staticdev=""
+FILES_${PN}-typer-staticdev="${libdir}/erlang/lib/typer-*/lib/*.a ${libdir}/erlang/lib/typer-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-typer="1"
+DESCRIPTION_${PN}-typer=""
+RDEPENDS_${PN}-typer=""
+FILES_${PN}-typer="${bindir}/typer ${libdir}/erlang/bin/typer ${libdir}/erlang/lib/typer-* ${libdir}/erlang/erts-*/bin/typer "
+
+ALLOW_EMPTY_${PN}-webtool-doc="1"
+DESCRIPTION_${PN}-webtool-doc=""
+RDEPENDS_${PN}-webtool-doc=""
+FILES_${PN}-webtool-doc="${libdir}/erlang/lib/webtool-*/examples ${libdir}/erlang/lib/webtool-*/doc ${libdir}/erlang/lib/webtool-*/man "
+
+ALLOW_EMPTY_${PN}-webtool-dbg="1"
+DESCRIPTION_${PN}-webtool-dbg=""
+RDEPENDS_${PN}-webtool-dbg=""
+FILES_${PN}-webtool-dbg="${libdir}/erlang/lib/webtool-*/bin/.debug ${libdir}/erlang/lib/webtool-*/lib/.debug ${libdir}/erlang/lib/webtool-*/priv/lib/.debug ${libdir}/erlang/lib/webtool-*/priv/obj/.debug ${libdir}/erlang/lib/webtool-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-webtool-dev="1"
+DESCRIPTION_${PN}-webtool-dev=""
+RDEPENDS_${PN}-webtool-dev=""
+FILES_${PN}-webtool-dev="${libdir}/erlang/lib/webtool-*/*src ${libdir}/erlang/lib/webtool-*/include ${libdir}/erlang/lib/webtool-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-webtool-staticdev="1"
+DESCRIPTION_${PN}-webtool-staticdev=""
+RDEPENDS_${PN}-webtool-staticdev=""
+FILES_${PN}-webtool-staticdev="${libdir}/erlang/lib/webtool-*/lib/*.a ${libdir}/erlang/lib/webtool-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-webtool="1"
+DESCRIPTION_${PN}-webtool=""
+RDEPENDS_${PN}-webtool=""
+FILES_${PN}-webtool="${libdir}/erlang/lib/webtool-* "
+
+ALLOW_EMPTY_${PN}-xmerl-doc="1"
+DESCRIPTION_${PN}-xmerl-doc=""
+RDEPENDS_${PN}-xmerl-doc=""
+FILES_${PN}-xmerl-doc="${libdir}/erlang/lib/xmerl-*/examples ${libdir}/erlang/lib/xmerl-*/doc ${libdir}/erlang/lib/xmerl-*/man "
+
+ALLOW_EMPTY_${PN}-xmerl-dbg="1"
+DESCRIPTION_${PN}-xmerl-dbg=""
+RDEPENDS_${PN}-xmerl-dbg=""
+FILES_${PN}-xmerl-dbg="${libdir}/erlang/lib/xmerl-*/bin/.debug ${libdir}/erlang/lib/xmerl-*/lib/.debug ${libdir}/erlang/lib/xmerl-*/priv/lib/.debug ${libdir}/erlang/lib/xmerl-*/priv/obj/.debug ${libdir}/erlang/lib/xmerl-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-xmerl-dev="1"
+DESCRIPTION_${PN}-xmerl-dev=""
+RDEPENDS_${PN}-xmerl-dev=""
+FILES_${PN}-xmerl-dev="${libdir}/erlang/lib/xmerl-*/*src ${libdir}/erlang/lib/xmerl-*/include ${libdir}/erlang/lib/xmerl-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-xmerl-staticdev="1"
+DESCRIPTION_${PN}-xmerl-staticdev=""
+RDEPENDS_${PN}-xmerl-staticdev=""
+FILES_${PN}-xmerl-staticdev="${libdir}/erlang/lib/xmerl-*/lib/*.a ${libdir}/erlang/lib/xmerl-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-xmerl="1"
+DESCRIPTION_${PN}-xmerl=""
+RDEPENDS_${PN}-xmerl=""
+FILES_${PN}-xmerl="${libdir}/erlang/lib/xmerl-* "
+
+ALLOW_EMPTY_${PN}-odbc-doc="1"
+DESCRIPTION_${PN}-odbc-doc=""
+RDEPENDS_${PN}-odbc-doc=""
+FILES_${PN}-odbc-doc="${libdir}/erlang/lib/odbc-*/examples ${libdir}/erlang/lib/odbc-*/doc ${libdir}/erlang/lib/odbc-*/man "
+
+ALLOW_EMPTY_${PN}-odbc-dbg="1"
+DESCRIPTION_${PN}-odbc-dbg=""
+RDEPENDS_${PN}-odbc-dbg=""
+FILES_${PN}-odbc-dbg="${libdir}/erlang/lib/odbc-*/bin/.debug ${libdir}/erlang/lib/odbc-*/lib/.debug ${libdir}/erlang/lib/odbc-*/priv/lib/.debug ${libdir}/erlang/lib/odbc-*/priv/obj/.debug ${libdir}/erlang/lib/odbc-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-odbc-dev="1"
+DESCRIPTION_${PN}-odbc-dev=""
+RDEPENDS_${PN}-odbc-dev=""
+FILES_${PN}-odbc-dev="${libdir}/erlang/lib/odbc-*/*src ${libdir}/erlang/lib/odbc-*/include ${libdir}/erlang/lib/odbc-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-odbc-staticdev="1"
+DESCRIPTION_${PN}-odbc-staticdev=""
+RDEPENDS_${PN}-odbc-staticdev=""
+FILES_${PN}-odbc-staticdev="${libdir}/erlang/lib/odbc-*/lib/*.a ${libdir}/erlang/lib/odbc-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-odbc="1"
+DESCRIPTION_${PN}-odbc=""
+RDEPENDS_${PN}-odbc=""
+FILES_${PN}-odbc="${libdir}/erlang/lib/odbc-* "
+
+ALLOW_EMPTY_${PN}-ose-doc="1"
+DESCRIPTION_${PN}-ose-doc=""
+RDEPENDS_${PN}-ose-doc=""
+FILES_${PN}-ose-doc="${libdir}/erlang/lib/ose-*/examples ${libdir}/erlang/lib/ose-*/doc ${libdir}/erlang/lib/ose-*/man "
+
+ALLOW_EMPTY_${PN}-ose-dbg="1"
+DESCRIPTION_${PN}-ose-dbg=""
+RDEPENDS_${PN}-ose-dbg=""
+FILES_${PN}-ose-dbg="${libdir}/erlang/lib/ose-*/bin/.debug ${libdir}/erlang/lib/ose-*/lib/.debug ${libdir}/erlang/lib/ose-*/priv/lib/.debug ${libdir}/erlang/lib/ose-*/priv/obj/.debug ${libdir}/erlang/lib/ose-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-ose-dev="1"
+DESCRIPTION_${PN}-ose-dev=""
+RDEPENDS_${PN}-ose-dev=""
+FILES_${PN}-ose-dev="${libdir}/erlang/lib/ose-*/*src ${libdir}/erlang/lib/ose-*/include ${libdir}/erlang/lib/ose-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-ose-staticdev="1"
+DESCRIPTION_${PN}-ose-staticdev=""
+RDEPENDS_${PN}-ose-staticdev=""
+FILES_${PN}-ose-staticdev="${libdir}/erlang/lib/ose-*/lib/*.a ${libdir}/erlang/lib/ose-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-ose="1"
+DESCRIPTION_${PN}-ose=""
+RDEPENDS_${PN}-ose=""
+FILES_${PN}-ose="${libdir}/erlang/lib/ose-* "
+
+ALLOW_EMPTY_${PN}-erts-doc="1"
+DESCRIPTION_${PN}-erts-doc=""
+RDEPENDS_${PN}-erts-doc=""
+FILES_${PN}-erts-doc="${libdir}/erlang/lib/erts-*/examples ${libdir}/erlang/lib/erts-*/doc ${libdir}/erlang/lib/erts-*/man "
+
+ALLOW_EMPTY_${PN}-erts-dbg="1"
+DESCRIPTION_${PN}-erts-dbg=""
+RDEPENDS_${PN}-erts-dbg=""
+FILES_${PN}-erts-dbg="${libdir}/erlang/lib/erts-*/bin/.debug ${libdir}/erlang/lib/erts-*/lib/.debug ${libdir}/erlang/lib/erts-*/priv/lib/.debug ${libdir}/erlang/lib/erts-*/priv/obj/.debug ${libdir}/erlang/lib/erts-*/priv/bin/.debug "
+
+ALLOW_EMPTY_${PN}-erts-dev="1"
+DESCRIPTION_${PN}-erts-dev=""
+RDEPENDS_${PN}-erts-dev=""
+FILES_${PN}-erts-dev="${libdir}/erlang/lib/erts-*/*src ${libdir}/erlang/lib/erts-*/include ${libdir}/erlang/lib/erts-*/priv/obj "
+
+ALLOW_EMPTY_${PN}-erts-staticdev="1"
+DESCRIPTION_${PN}-erts-staticdev=""
+RDEPENDS_${PN}-erts-staticdev=""
+FILES_${PN}-erts-staticdev="${libdir}/erlang/lib/erts-*/lib/*.a ${libdir}/erlang/lib/erts-*/priv/lib/*.a "
+
+ALLOW_EMPTY_${PN}-erts="1"
+DESCRIPTION_${PN}-erts=""
+RDEPENDS_${PN}-erts=""
+FILES_${PN}-erts="${bindir} ${libdir}/erlang/releases ${libdir}/erlang/bin ${libdir}/erlang/erts-*/bin "
+
+ALLOW_EMPTY_${PN}-doc="1"
+DESCRIPTION_${PN}-doc=""
+RDEPENDS_${PN}-doc=""
+FILES_${PN}-doc+="${libdir}/erlang/erts-*/doc ${libdir}/erlang/erts-*/man ${libdir}/erlang/lib/*/examples ${libdir}/erlang/misc "
+
+ALLOW_EMPTY_${PN}-dev="1"
+DESCRIPTION_${PN}-dev=""
+RDEPENDS_${PN}-dev=""
+FILES_${PN}-dev+="${libdir}/erlang/erts-*/include ${libdir}/erlang/erts-*/src ${libdir}/erlang/usr/include "
+
+ALLOW_EMPTY_${PN}-dbg="1"
+DESCRIPTION_${PN}-dbg=""
+RDEPENDS_${PN}-dbg=""
+FILES_${PN}-dbg+="${libdir}/erlang/bin/.debug ${libdir}/erlang/erts-*/bin/.debug "
+
+ALLOW_EMPTY_${PN}-staticdev="1"
+DESCRIPTION_${PN}-staticdev=""
+RDEPENDS_${PN}-staticdev=""
+FILES_${PN}-staticdev+="${libdir}/erlang/usr/lib/*.a ${libdir}/erlang/usr/lib/internal/*.a ${libdir}/erlang/erts-*/lib/*.a ${libdir}/erlang/erts-*/lib/internal/* "
+
+ALLOW_EMPTY_${PN}="1"
+DESCRIPTION_${PN}=""
+RDEPENDS_${PN}="${PN}-erts ${PN}-kernel ${PN}-stdlib ${PN}-sasl"
+FILES_${PN}+=""
+
+DESCRIPTION_${PN}-modules="All Erlang modules"
+RDEPENDS_${PN}-modules="${PN} ${PN}-appmon ${PN}-appmon-doc ${PN}-asn1 ${PN}-asn1-doc ${PN}-common-test ${PN}-common-test-doc ${PN}-compiler ${PN}-compiler-doc ${PN}-cosevent ${PN}-cosevent-doc ${PN}-coseventdomain ${PN}-coseventdomain-doc ${PN}-cosfiletransfer ${PN}-cosfiletransfer-doc ${PN}-cosnotification ${PN}-cosnotification-doc ${PN}-cosproperty ${PN}-cosproperty-doc ${PN}-costime ${PN}-costime-doc ${PN}-costransactions ${PN}-costransactions-doc ${PN}-crypto ${PN}-crypto-doc ${PN}-debugger ${PN}-debugger-doc ${PN}-dialyzer ${PN}-dialyzer-doc ${PN}-diameter ${PN}-diameter-doc ${PN}-doc ${PN}-edoc ${PN}-edoc-doc ${PN}-eldap ${PN}-eldap-doc ${PN}-erl-docgen ${PN}-erl-docgen-doc ${PN}-erl-interface ${PN}-erl-interface-doc ${PN}-erts ${PN}-erts-doc ${PN}-et ${PN}-et-doc ${PN}-eunit ${PN}-eunit-doc ${PN}-gs ${PN}-gs-doc ${PN}-hipe ${PN}-hipe-doc ${PN}-ic ${PN}-ic-doc ${PN}-inets ${PN}-inets-doc ${PN}-jinterface ${PN}-jinterface-doc ${PN}-kernel ${PN}-kernel-doc ${PN}-megaco ${PN}-megaco-doc ${PN}-mnesia ${PN}-mnesia-doc ${PN}-observer ${PN}-observer-doc ${PN}-odbc ${PN}-odbc-doc ${PN}-orber ${PN}-orber-doc ${PN}-os-mon ${PN}-os-mon-doc ${PN}-ose ${PN}-ose-doc ${PN}-otp-mibs ${PN}-otp-mibs-doc ${PN}-parsetools ${PN}-parsetools-doc ${PN}-percept ${PN}-percept-doc ${PN}-pman ${PN}-pman-doc ${PN}-public-key ${PN}-public-key-doc ${PN}-reltool ${PN}-reltool-doc ${PN}-runtime-tools ${PN}-runtime-tools-doc ${PN}-sasl ${PN}-sasl-doc ${PN}-snmp ${PN}-snmp-doc ${PN}-ssh ${PN}-ssh-doc ${PN}-ssl ${PN}-ssl-doc ${PN}-stdlib ${PN}-stdlib-doc ${PN}-syntax-tools ${PN}-syntax-tools-doc ${PN}-test-server ${PN}-test-server-doc ${PN}-toolbar ${PN}-toolbar-doc ${PN}-tools ${PN}-tools-doc ${PN}-tv ${PN}-tv-doc ${PN}-typer ${PN}-typer-doc ${PN}-webtool ${PN}-webtool-doc ${PN}-xmerl ${PN}-xmerl-doc  "
+ALLOW_EMPTY_${PN}-modules = "1"
+
+

--- a/recipes-devtools/erlang/erlang-19.0.inc
+++ b/recipes-devtools/erlang/erlang-19.0.inc
@@ -1,0 +1,2 @@
+SRC_URI[md5sum] = "beeede1135b9192aab09136ea61c0057"
+SRC_URI[sha256sum] = "107b629aa7aea1bf76df0197629a50ce4fea61143ebb0e9a1b633b1fbaf9beb7"

--- a/recipes-devtools/erlang/erlang-native_19.0.bb
+++ b/recipes-devtools/erlang/erlang-native_19.0.bb
@@ -1,0 +1,25 @@
+include erlang.inc
+include erlang-${PV}.inc
+
+inherit native
+
+PR = "r0"
+
+EXTRA_OECONF = "--with-ssl=${STAGING_DIR_NATIVE}"
+
+CACHED_CONFIGUREVARS += "ac_cv_prog_javac_ver_1_2=no ac_cv_prog_javac_ver_1_5=no erl_xcomp_sysroot=${STAGING_DIR_NATIVE}"
+
+do_configure() {
+    cd ${S}; ./otp_build autoconf
+    TARGET=${HOST_SYS} \
+    oe_runconf
+}
+
+do_compile_prepend() {
+    export TARGET=${HOST_SYS}
+}
+
+do_install_prepend() {
+    export TARGET=${HOST_SYS}
+}
+

--- a/recipes-devtools/erlang/erlang_19.0.bb
+++ b/recipes-devtools/erlang/erlang_19.0.bb
@@ -1,0 +1,64 @@
+include erlang.inc
+include erlang-${PV}.inc
+DEPENDS += "erlang-native openssl"
+
+require erlang-${PV}-manifest.inc
+
+PR = "r0"
+
+PACKAGECONFIG ??= ""
+
+PACKAGECONFIG[odbc] = "--with-odbc,-without-odbc,libodbc"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+EXTRA_OEMAKE = "BUILD_CC='${BUILD_CC}'"
+
+# EXTRA_OECONF_append_arm = " --disable-smp-support --disable-hipe"
+# EXTRA_OECONF_append_armeb = " --disable-smp-support --disable-hipe"
+EXTRA_OECONF_append_mipsel = " --disable-smp-support --disable-hipe"
+EXTRA_OECONF_append_sh3 = " --disable-smp-support --disable-hipe"
+EXTRA_OECONF_append_sh4 = " --disable-smp-support --disable-hipe"
+
+NATIVE_BIN = "${STAGING_LIBDIR_NATIVE}/erlang/bin"
+
+CACHED_CONFIGUREVARS += "ac_cv_prog_javac_ver_1_2=no ac_cv_prog_javac_ver_1_5=no erl_xcomp_sysroot=${STAGING_DIR_TARGET}"
+
+do_configure() {
+    cd ${S}; ./otp_build autoconf; cd -
+    cd ${S}/erts; autoreconf; cd -
+    cd ${S}/lib/wx; autoreconf; cd -
+
+    touch ${S}/lib/wx/SKIP
+    touch ${S}/lib/odbc/SKIP
+
+    . ${CONFIG_SITE}
+
+    SHLIB_LD='${CC}' \
+    oe_runconf
+
+    sed -i -e 's|$(ERL_TOP)/bin/dialyzer|${NATIVE_BIN}/dialyzer --output_plt $@ -pa $(ERL_TOP)/lib/kernel/ebin -pa $(ERL_TOP)/lib/stdlib/ebin|' lib/dialyzer/src/Makefile
+}
+
+do_compile() {
+    TARGET=${TARGET_SYS} \
+    PATH=${NATIVE_BIN}:$PATH \
+    oe_runmake noboot
+}
+
+do_install() {
+    TARGET=${TARGET_SYS} \
+    PATH=${NATIVE_BIN}:$PATH \
+    oe_runmake 'INSTALL_PREFIX=${D}' install
+    for f in erl start
+        do sed -i -e 's:ROOTDIR=.*:ROOTDIR=${libdir}/erlang:' \
+            ${D}/${libdir}/erlang/erts-*/bin/$f ${D}/${libdir}/erlang/bin/$f
+    done
+
+    rm -f ${D}/${libdir}/erlang/Install
+
+    # Actually wx is not suitable with erlang embedded
+    rm -rf ${D}/${libdir}/erlang/lib/wx-*
+    chown -R root:root ${D}${libdir}/erlang
+}
+

--- a/scripts/contrib/erlang/generate-manifest
+++ b/scripts/contrib/erlang/generate-manifest
@@ -190,6 +190,10 @@ SPEC = {
     '18.3.4': {
         'ERTS_VERSION': '7.3',
         'modules' : COMMON_MODULES,
+    },
+    '19.0': {
+        'ERTS_VERSION': '8.0',
+        'modules' : COMMON_MODULES,
     }
 }
 


### PR DESCRIPTION
This is a direct copy of OTP 18.3.4 support.  The manifest might need to be tweaked, but it appears to be working