### PR TITLE
erlang.inc: Fix paths

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -12,7 +12,7 @@ SRC_URI = "git://github.com/erlang/otp;branch=master"
 SRC_URI += "file://fix-wx-configure.patch"
 SRC_URI += "file://erlang-fix-build-issue-in-Yocto.patch"
 
-S = "${WORKDIR}/otp-OTP-${PV}"
+S = "${WORKDIR}/git"
 
 PARALLEL_MAKE = ""
 


### PR DESCRIPTION
Current build is broken as patches will be applied to
"${WORKDIR}/otp-OTP-${PV}" while git actually checks out the code in
"${WORKDIR}/git". This patch fixes it by applying patches to
"${WORKDIR}/git".

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>