### PR TITLE
erlang.inc: Declare openssl-native as build-time dependency

### DIFF
--- a/recipes-devtools/erlang/erlang.inc
+++ b/recipes-devtools/erlang/erlang.inc
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ff253ad767462c46be284da12dda33e8"
 
 DEPENDS = "ncurses zlib"
-DEPENDS_append_class-native = " ncurses-native"
+DEPENDS_append_class-native = " ncurses-native openssl-native"
 
 SRC_URI = "git://github.com/erlang/otp;branch=master"
 SRC_URI += "file://fix-wx-configure.patch"


### PR DESCRIPTION
With the introduction of recipe-specific sysroots in pyro, the
build-time dependencies has to be explicitly declared.

Signed-off-by: Henrik Nymann Jensen <hnje@prevas.dk>