### PR TITLE
erlinit: fix download url

### DIFF
--- a/recipes-core/erlinit/erlinit_git.bb
+++ b/recipes-core/erlinit/erlinit_git.bb
@@ -8,7 +8,7 @@ SRCREV = "53b0a4dfc5aab5f883652527e29e2db39ac546ae"
 PV = "1.6.0-git${SRCPV}"
 PR = "r0"
 
-SRC_URI = "git://github.com/nerves-project/erlinit;branch=master \
+SRC_URI = "git://github.com/nerves-project/erlinit;branch=main \
     file://erlinit.config \
     "
 


### PR DESCRIPTION
Hello,

[The erlinit git repository](https://github.com/nerves-project/erlinit) has changed the name of the branches, from "master" to "main", causing errors in the fetch step:

```
ERROR: erlinit-1.6.0-gitAUTOINC+53b0a4dfc5-r0 do_fetch: Fetcher failure: Unable to find revision 53b0a4dfc5aab5f883652527e29e2db39ac546ae in branch master even from upstream
ERROR: erlinit-1.6.0-gitAUTOINC+53b0a4dfc5-r0 do_fetch: Fetcher failure for URL: 'git://github.com/nerves-project/erlinit;branch=master'. Unable to fetch URL from any source.
ERROR: Logfile of failure stored in: [...]/build/tmp/work/aarch64-poky-linux/erlinit/1.6.0-gitAUTOINC+53b0a4dfc5-r0/temp/log.do_fetch.26591
ERROR: Task ([...]/poky/meta-erlang/recipes-core/erlinit/erlinit_git.bb:do_fetch) failed with exit code '1'
```

This patch fixes the URL, allowing the build to complete.